### PR TITLE
Issue #17 - Do not remove recoverable consumers from consumer channel pool on terminate

### DIFF
--- a/rabbitmq/src/main/java/io/micronaut/configuration/rabbitmq/intercept/RabbitMQConsumerAdvice.java
+++ b/rabbitmq/src/main/java/io/micronaut/configuration/rabbitmq/intercept/RabbitMQConsumerAdvice.java
@@ -194,7 +194,12 @@ public class RabbitMQConsumerAdvice implements ExecutableMethodProcessor<RabbitL
 
                     @Override
                     public void handleTerminate(String consumerTag) {
-                        ConsumerState state = consumerChannels.remove(channel);
+                        ConsumerState state;
+                        if (channel instanceof RecoverableChannel) {
+                            state = consumerChannels.get(channel);
+                        } else {
+                            state = consumerChannels.remove(channel);
+                        }
                         if (state != null) {
                             state.channelPool.returnChannel(channel);
                             if (LOG.isDebugEnabled()) {

--- a/rabbitmq/src/main/java/io/micronaut/configuration/rabbitmq/intercept/RabbitMQConsumerAdvice.java
+++ b/rabbitmq/src/main/java/io/micronaut/configuration/rabbitmq/intercept/RabbitMQConsumerAdvice.java
@@ -194,16 +194,17 @@ public class RabbitMQConsumerAdvice implements ExecutableMethodProcessor<RabbitL
 
                     @Override
                     public void handleTerminate(String consumerTag) {
-                        ConsumerState state;
                         if (channel instanceof RecoverableChannel) {
-                            state = consumerChannels.get(channel);
-                        } else {
-                            state = consumerChannels.remove(channel);
-                        }
-                        if (state != null) {
-                            state.channelPool.returnChannel(channel);
                             if (LOG.isDebugEnabled()) {
-                                LOG.debug("The channel was terminated. The consumer [{}] will no longer receive messages", clientTag);
+                                LOG.debug("The channel was been terminated.  Automatic recovery attempt is underway for consumer [{}]", clientTag);
+                            }
+                        } else {
+                            ConsumerState state = consumerChannels.remove(channel);
+                            if (state != null) {
+                                state.channelPool.returnChannel(channel);
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug("The channel was terminated. The consumer [{}] will no longer receive messages", clientTag);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Issue #17 

Automatic removal of recoverable channels from `RabbitMQConsumerAdvice.consumerChannels` on channel terminate breaks the consumer recovery process.  If RabbitMQ goes down, any consumer channels will be automatically terminated; the termination process removes them from the `consumerChannels` map, but the recovery process does not put them back, and so the "recovered" consumers are unable to receive messages.  This change leaves the recoverable channels in `consumerChannels` while the connection is being retried.  (It doesn't appear that there's any recovery timeout or recovery failure handling in place, so presumably the connection will be retried forever.)