### PR TITLE
add missing useJUnitPlatform for groovy docs test

### DIFF
--- a/docs-examples/example-groovy/build.gradle
+++ b/docs-examples/example-groovy/build.gradle
@@ -20,6 +20,8 @@ dependencies {
 }
 
 test {
+    useJUnitPlatform()
+
     jvmArgs '-Duser.country=US'
     jvmArgs '-Duser.language=en'
     failFast = true


### PR DESCRIPTION
I noticed none of the junit test for groovy are not run in the CI environment. I'm just going on the assumption this is just an oversight. It can be verified in the last running CI test. https://github.com/micronaut-projects/micronaut-rabbitmq/runs/893862032#step:7:410

![image](https://user-images.githubusercontent.com/854359/88110855-c2483600-cb61-11ea-9c0c-2d17e30ace7f.png)
