### PR TITLE
Message mapping annotation

### DIFF
--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/annotation/Queue.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/annotation/Queue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/annotation/Queue.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/annotation/Queue.java
@@ -16,6 +16,7 @@
 package io.micronaut.rabbitmq.annotation;
 
 import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.messaging.annotation.MessageMapping;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -38,6 +39,7 @@ public @interface Queue {
     /**
      * @return The queue to subscribe to.
      */
+    @AliasFor(annotation = MessageMapping.class, member = "value")
     String value();
 
     /**

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/annotation/QueueAnnotationSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/annotation/QueueAnnotationSpec.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.rabbitmq.annotation
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.messaging.annotation.MessageMapping
+import io.micronaut.rabbitmq.AbstractRabbitMQTest
+
+class QueueAnnotationSpec extends AbstractRabbitMQTest {
+
+    void 'test that @Queue value aliases to @MessageMapping'() {
+        given:
+        ApplicationContext ctx = startContext()
+        def definition = ctx.getBeanDefinition(MyConsumer)
+
+        when:
+        def method = definition.getRequiredMethod('receive', String)
+        def annotationValue = method.getValue(MessageMapping, String[])
+
+        then:
+        annotationValue.isPresent()
+        annotationValue.get().contains 'simple'
+
+        cleanup:
+        ctx.close()
+    }
+
+    @Requires(property = 'spec.name', value = 'QueueAnnotationSpec')
+    @RabbitListener
+    static class MyConsumer {
+
+        List<String> stuff = []
+
+        @Queue('simple')
+        void receive(String thing) {
+            stuff.add(thing)
+        }
+    }
+
+}


### PR DESCRIPTION
The `@Queue` annotation's value is now an alias for `@MessageMapping`.