### PR TITLE
Changes to be compatible with 3.x

### DIFF
--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/annotation/Queue.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/annotation/Queue.java
@@ -16,6 +16,7 @@
 package io.micronaut.rabbitmq.annotation;
 
 import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.context.annotation.Executable;
 import io.micronaut.messaging.annotation.MessageMapping;
 
 import java.lang.annotation.Documented;
@@ -34,6 +35,7 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
+@Executable
 public @interface Queue {
 
     /**

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
@@ -71,7 +71,7 @@ import java.util.concurrent.ExecutorService;
  * @since 1.1.0
  */
 @Singleton
-public class RabbitMQConsumerAdvice implements ExecutableMethodProcessor<RabbitListener>, AutoCloseable {
+public class RabbitMQConsumerAdvice implements ExecutableMethodProcessor<Queue>, AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(RabbitMQConsumerAdvice.class);
 
@@ -170,7 +170,7 @@ public class RabbitMQConsumerAdvice implements ExecutableMethodProcessor<RabbitL
             });
 
             io.micronaut.context.Qualifier<Object> qualifer = beanDefinition
-                    .getAnnotationTypeByStereotype(Qualifier.class)
+                    .getAnnotationNameByStereotype("javax.inject.Qualifier")
                     .map(type -> Qualifiers.byAnnotation(beanDefinition, type))
                     .orElse(null);
 


### PR DESCRIPTION
Given the change to the consumer is not binary compatible with code compiled against older versions of this library, this should target Micronaut 3