### PR TITLE
Upgrade to Gradle 7 and latest versions of dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
     repositories {
-        maven { url "https://repo.grails.org/grails/core" }
+        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:3.0.3"
+        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:4.0.0"
     }
 }
 

--- a/docs-examples/example-kotlin/build.gradle
+++ b/docs-examples/example-kotlin/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     kaptTest(enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion"))
     kaptTest "io.micronaut:micronaut-inject-java"
-    testImplementation 'io.kotlintest:kotlintest-runner-junit5:3.4.2'
+    testImplementation "io.kotest:kotest-runner-junit5:$kotestVersion"
     testImplementation "io.projectreactor:reactor-core"
     testRuntimeOnly "io.micronaut.reactor:micronaut-reactor"
 }

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/AbstractRabbitMQTest.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/AbstractRabbitMQTest.kt
@@ -1,11 +1,11 @@
 package io.micronaut.rabbitmq
 
-import io.kotlintest.specs.AbstractBehaviorSpec
-import io.kotlintest.specs.BehaviorSpec
+import io.kotest.core.spec.style.BehaviorSpec
 import io.micronaut.context.ApplicationContext
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
+import kotlin.time.ExperimentalTime
 
-abstract class AbstractRabbitMQTest(body: AbstractBehaviorSpec.() -> Unit = {}): BehaviorSpec(body) {
+abstract class AbstractRabbitMQTest(body: BehaviorSpec.() -> Unit = {}): BehaviorSpec(body) {
 
     companion object {
         val rabbitContainer = KGenericContainer("library/rabbitmq:3.7")

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/acknowledge/type/AcknowledgeSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/acknowledge/type/AcknowledgeSpec.kt
@@ -1,11 +1,12 @@
 package io.micronaut.rabbitmq.docs.consumer.acknowledge.type
 
-import io.kotlintest.eventually
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
-import org.opentest4j.AssertionFailedError
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class AcknowledgeSpec : AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -25,7 +26,7 @@ class AcknowledgeSpec : AbstractRabbitMQTest({
             // end::producer[]
 
             then("The messages are received") {
-                eventually(10.seconds, AssertionFailedError::class.java) {
+                    eventually(Duration.seconds(10)) {
                     productListener.messageCount.get() shouldBe 5
                 }
             }

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/connection/ConnectionSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/connection/ConnectionSpec.kt
@@ -1,11 +1,12 @@
 package io.micronaut.rabbitmq.docs.consumer.connection
 
-import io.kotlintest.eventually
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
-import org.opentest4j.AssertionFailedError
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class ConnectionSpec : AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -25,7 +26,7 @@ class ConnectionSpec : AbstractRabbitMQTest({
 // end::producer[]
 
             then("the message is consumed") {
-                eventually(10.seconds, AssertionFailedError::class.java) {
+                eventually(Duration.seconds(10)) {
                     productListener.messageLengths.size shouldBe 1
                     productListener.messageLengths[0] shouldBe "connection-test"
                 }

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/custom/annotation/DeliveryTagSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/custom/annotation/DeliveryTagSpec.kt
@@ -1,11 +1,12 @@
 package io.micronaut.rabbitmq.docs.consumer.custom.annotation
 
-import io.kotlintest.eventually
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
-import org.opentest4j.AssertionFailedError
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class DeliveryTagSpec : AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -24,7 +25,7 @@ class DeliveryTagSpec : AbstractRabbitMQTest({
             // end::producer[]
 
             then("The messages are received") {
-                eventually(10.seconds, AssertionFailedError::class.java) {
+                eventually(Duration.seconds(10)) {
                     productListener.messages.size shouldBe 3
                 }
             }

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/custom/type/ProductInfoSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/custom/type/ProductInfoSpec.kt
@@ -1,12 +1,13 @@
 package io.micronaut.rabbitmq.docs.consumer.custom.type
 
-import io.kotlintest.eventually
-import io.kotlintest.matchers.collections.shouldExist
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.collections.shouldExist
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
-import org.opentest4j.AssertionFailedError
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class ProductInfoSpec : AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -25,7 +26,7 @@ class ProductInfoSpec : AbstractRabbitMQTest({
             // end::producer[]
 
             then("The messages are received") {
-                eventually(10.seconds, AssertionFailedError::class.java) {
+                eventually(Duration.seconds(10)) {
                     productListener.messages.size shouldBe 3
                     productListener.messages shouldExist { p -> p.size == "small" && p.count == 10L && p.sealed }
                     productListener.messages shouldExist { p -> p.size == "medium" && p.count == 20L && p.sealed }

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/executor/CustomExecutorSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/executor/CustomExecutorSpec.kt
@@ -1,11 +1,12 @@
 package io.micronaut.rabbitmq.docs.consumer.executor
 
-import io.kotlintest.eventually
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
-import org.opentest4j.AssertionFailedError
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class CustomExecutorSpec : AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -25,7 +26,7 @@ class CustomExecutorSpec : AbstractRabbitMQTest({
 // end::producer[]
 
             then("the message is consumed") {
-                eventually(10.seconds, AssertionFailedError::class.java) {
+                eventually(Duration.seconds(10)) {
                     productListener.messageLengths.size shouldBe 1
                     productListener.messageLengths[0] shouldBe "custom-executor-test"
                 }

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/types/TypeBindingSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/types/TypeBindingSpec.kt
@@ -1,12 +1,13 @@
 package io.micronaut.rabbitmq.docs.consumer.types
 
-import io.kotlintest.eventually
-import io.kotlintest.matchers.collections.shouldContain
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
-import org.opentest4j.AssertionFailedError
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class TypeBindingSpec : AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -25,7 +26,7 @@ class TypeBindingSpec : AbstractRabbitMQTest({
             // end::producer[]
 
             then("The messages are received") {
-                eventually(10.seconds, AssertionFailedError::class.java) {
+                eventually(Duration.seconds(10)) {
                     productListener.messages.size shouldBe 3
                     productListener.messages shouldContain "exchange: [], routingKey: [product], contentType: [text/html]"
                     productListener.messages shouldContain "exchange: [], routingKey: [product], contentType: [application/json]"

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/exchange/CustomExchangeSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/exchange/CustomExchangeSpec.kt
@@ -1,13 +1,13 @@
 package io.micronaut.rabbitmq.docs.exchange
 
-import io.kotlintest.eventually
-import io.kotlintest.matchers.collections.shouldExist
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.collections.shouldExist
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
-import org.opentest4j.AssertionFailedError
-
+@OptIn(ExperimentalTime::class)
 class CustomExchangeSpec: AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -26,8 +26,8 @@ class CustomExchangeSpec: AbstractRabbitMQTest({
 
             then("the messages are received") {
                 val messages = listener.receivedAnimals
-                eventually(10.seconds, AssertionFailedError::class.java) {
-                    messages.size shouldBe 4
+                eventually(Duration.seconds(10)) {
+                    messages.size shouldBe  4
                     messages shouldExist({ animal: Animal ->
                         Cat::class.isInstance(animal) && animal.name == "Whiskers"
                     })

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/headers/HeadersSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/headers/HeadersSpec.kt
@@ -1,12 +1,13 @@
 package io.micronaut.rabbitmq.docs.headers
 
-import io.kotlintest.eventually
-import io.kotlintest.matchers.collections.shouldContain
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
-import org.opentest4j.AssertionFailedError
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class HeadersSpec : AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -26,7 +27,7 @@ class HeadersSpec : AbstractRabbitMQTest({
             // end::producer[]
 
             then("The messages are received") {
-                eventually(10.seconds, AssertionFailedError::class.java) {
+                eventually(Duration.seconds(10)) {
                     productListener.messageProperties.size shouldBe 4
                     productListener.messageProperties shouldContain "true|10|small"
                     productListener.messageProperties shouldContain "true|20|medium"

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/parameters/BindingSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/parameters/BindingSpec.kt
@@ -1,12 +1,13 @@
 package io.micronaut.rabbitmq.docs.parameters
 
-import io.kotlintest.eventually
-import io.kotlintest.matchers.collections.shouldContain
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
-import org.opentest4j.AssertionFailedError
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class BindingSpec: AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -24,7 +25,7 @@ class BindingSpec: AbstractRabbitMQTest({
             // end::producer[]
 
             then("The messages are received") {
-                eventually(10.seconds, AssertionFailedError::class.java) {
+                eventually(Duration.seconds(10)) {
                     productListener.messageLengths.size shouldBe 2
                     productListener.messageLengths shouldContain 12
                     productListener.messageLengths shouldContain 13

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/properties/PropertiesSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/properties/PropertiesSpec.kt
@@ -1,12 +1,13 @@
 package io.micronaut.rabbitmq.docs.properties
 
-import io.kotlintest.eventually
-import io.kotlintest.matchers.collections.shouldContain
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
-import org.opentest4j.AssertionFailedError
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class PropertiesSpec : AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -25,7 +26,7 @@ class PropertiesSpec : AbstractRabbitMQTest({
             then("the messages are received") {
                 val productListener = ctx.getBean(ProductListener::class.java)
 
-                eventually(10.seconds, AssertionFailedError::class.java) {
+                eventually(Duration.seconds(10)) {
                     productListener.messageProperties.size shouldBe 3
                     productListener.messageProperties shouldContain "guest|application/json|myApp"
                     productListener.messageProperties shouldContain "guest|text/html|myApp"

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/publisher/acknowledge/PublisherAcknowledgeSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/publisher/acknowledge/PublisherAcknowledgeSpec.kt
@@ -1,17 +1,18 @@
 package io.micronaut.rabbitmq.docs.publisher.acknowledge;
 
-import io.kotlintest.eventually
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
 import io.reactivex.CompletableObserver
 import io.reactivex.MaybeObserver
 import io.reactivex.disposables.Disposable
-import org.opentest4j.AssertionFailedError
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class PublisherAcknowledgeSpec : AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -81,7 +82,7 @@ class PublisherAcknowledgeSpec : AbstractRabbitMQTest({
 // end::producer[]
 
             then("The messages are published") {
-                eventually(10.seconds, AssertionFailedError::class.java) {
+                eventually(Duration.seconds(10)) {
                     errorCount.get() shouldBe 0
                     successCount.get() shouldBe 4
                 }

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/quickstart/QuickstartSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/quickstart/QuickstartSpec.kt
@@ -1,11 +1,12 @@
 package io.micronaut.rabbitmq.docs.quickstart
 
-import io.kotlintest.eventually
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
-import org.opentest4j.AssertionFailedError
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class QuickstartSpec: AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -22,7 +23,7 @@ productClient.send("quickstart".toByteArray())
 // end::producer[]
 
             then("the message is consumed") {
-                eventually(10.seconds, AssertionFailedError::class.java) {
+                eventually(Duration.seconds(10)) {
                     productListener.messageLengths.size shouldBe 1
                     productListener.messageLengths[0] shouldBe "quickstart"
                 }

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/rpc/RpcUppercaseSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/rpc/RpcUppercaseSpec.kt
@@ -1,8 +1,10 @@
 package io.micronaut.rabbitmq.docs.rpc
 
-import io.kotlintest.shouldBe
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class RpcUppercaseSpec: AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/serdes/ProductInfoSerDesSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/serdes/ProductInfoSerDesSpec.kt
@@ -1,12 +1,13 @@
 package io.micronaut.rabbitmq.docs.serdes
 
-import io.kotlintest.eventually
-import io.kotlintest.matchers.collections.shouldExist
-import io.kotlintest.seconds
-import io.kotlintest.shouldBe
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.collections.shouldExist
+import io.kotest.matchers.shouldBe
 import io.micronaut.rabbitmq.AbstractRabbitMQTest
-import org.opentest4j.AssertionFailedError
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class ProductInfoSerDesSpec: AbstractRabbitMQTest({
 
     val specName = javaClass.simpleName
@@ -25,7 +26,7 @@ class ProductInfoSerDesSpec: AbstractRabbitMQTest({
 // end::producer[]
 
             then("the message is consumed") {
-                eventually(10.seconds, AssertionFailedError::class.java) {
+                eventually(Duration.seconds(10)) {
                     listener.messages.size shouldBe 3
                     listener.messages shouldExist { p -> p.size == "small" && p.count == 10L && p.sealed }
                     listener.messages shouldExist { p -> p.size == "medium" && p.count == 20L && p.sealed }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectVersion=3.0.0-SNAPSHOT
-micronautDocsVersion=1.0.25
+micronautDocsVersion=2.0.0.RC1
 micronautVersion=2.4.4
 micronautTestVersion=2.3.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ spockVersion=2.0-M4-groovy-3.0
 rabbitVersion=5.12.0
 kotlinVersion=1.4.32
 junitVersion=5.7.1
+kotestVersion=4.6.0
 
 title=Micronaut RabbitMQ
 projectDesc=Integration between Micronaut and RabbitMQ

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 projectVersion=3.0.0-SNAPSHOT
 micronautDocsVersion=2.0.0.RC1
-micronautVersion=2.4.4
-micronautTestVersion=2.3.3
+micronautVersion=2.5.5
+micronautTestVersion=2.3.6
 
-groovyVersion=3.0.7
-spockVersion=2.0-M4-groovy-3.0
+groovyVersion=3.0.8
+spockVersion=2.0-groovy-3.0
 
 rabbitVersion=5.12.0
-kotlinVersion=1.4.32
-junitVersion=5.7.1
+kotlinVersion=1.5.10
+junitVersion=5.7.2
 kotestVersion=4.6.0
 
 title=Micronaut RabbitMQ

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
@@ -35,7 +35,6 @@ import io.micronaut.messaging.exceptions.MessageAcknowledgementException;
 import io.micronaut.messaging.exceptions.MessageListenerException;
 import io.micronaut.rabbitmq.annotation.Queue;
 import io.micronaut.rabbitmq.annotation.RabbitConnection;
-import io.micronaut.rabbitmq.annotation.RabbitListener;
 import io.micronaut.rabbitmq.annotation.RabbitProperty;
 import io.micronaut.rabbitmq.bind.RabbitBinderRegistry;
 import io.micronaut.rabbitmq.bind.RabbitConsumerState;
@@ -49,7 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PreDestroy;
-import javax.inject.Qualifier;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.util.Arrays;
@@ -64,7 +62,7 @@ import java.util.concurrent.ExecutorService;
 
 /**
  * An {@link ExecutableMethodProcessor} that will process all beans annotated
- * with {@link RabbitListener} and create and subscribe the relevant methods
+ * with {@link io.micronaut.rabbitmq.annotation.RabbitListener} and create and subscribe the relevant methods
  * as consumers to RabbitMQ queues.
  *
  * @author James Kleeh


### PR DESCRIPTION
- Upgrade to Gradle 7.0.2
- Upgrade to Kotest 4.6.0
- Fix checkstyle warning
- Ugprade micronaut, micronaut-test, spock, groovy and junit versions
