### PR TITLE
Add the connection name to the ChannelInitializer.initialize method

### DIFF
--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/ChannelPoolListener.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/ChannelPoolListener.groovy
@@ -9,7 +9,7 @@ import jakarta.inject.Singleton
 class ChannelPoolListener extends ChannelInitializer { // <2>
 
     @Override
-    void initialize(Channel channel) throws IOException { // <3>
+    void initialize(Channel channel, String name) throws IOException { // <3>
         channel.queueDeclare("product", false, false, false, ["x-max-priority": 100]) // <4>
 
         //docs/exchange

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/ChannelPoolListener.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/ChannelPoolListener.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class ChannelPoolListener extends ChannelInitializer { // <2>
 
     @Override
-    public void initialize(Channel channel) throws IOException { // <3>
+    public void initialize(Channel channel, String name) throws IOException { // <3>
         //docs/quickstart
         Map<String, Object> args = new HashMap<>();
         args.put("x-max-priority", 100);

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/ChannelPoolListener.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/ChannelPoolListener.kt
@@ -10,7 +10,7 @@ import java.io.IOException
 class ChannelPoolListener : ChannelInitializer() { // <2>
 
     @Throws(IOException::class)
-    override fun initialize(channel: Channel) { // <3>
+    override fun initialize(channel: Channel, name: String) { // <3>
         channel.queueDeclare("product", false, false, false, mapOf("x-max-priority" to 100)) // <4>
 
         //docs/exchange

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelInitializer.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelInitializer.java
@@ -37,9 +37,10 @@ public abstract class ChannelInitializer implements BeanCreatedEventListener<Cha
      * Do any work with a channel.
      *
      * @param channel The channel to use
+     * @param name The name of the channel pool, like configured under `rabbitmq.servers`
      * @throws IOException If any error occurs
      */
-    public abstract void initialize(Channel channel) throws IOException;
+    public abstract void initialize(Channel channel, String name) throws IOException;
 
     @Override
     public ChannelPool onCreated(BeanCreatedEvent<ChannelPool> event) {
@@ -47,7 +48,7 @@ public abstract class ChannelInitializer implements BeanCreatedEventListener<Cha
         Channel channel = null;
         try {
             channel = pool.getChannel();
-            initialize(channel);
+            initialize(channel, pool.getName());
         } catch (Throwable e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Initialization of the channel has failed due to error", e);

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/ChannelPoolListener.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/ChannelPoolListener.groovy
@@ -7,7 +7,7 @@ import jakarta.inject.Singleton
 class ChannelPoolListener extends ChannelInitializer {
 
     @Override
-    void initialize(Channel channel) throws IOException {
+    void initialize(Channel channel, String name) throws IOException {
         channel.queueDeclare("abc", false, false, false, [:])
         channel.queueDeclare("pojo", false, false, false, [:])
         channel.queueDeclare("pojo-list", false, false, false, [:])

--- a/src/main/docs/guide/initialization.adoc
+++ b/src/main/docs/guide/initialization.adoc
@@ -6,5 +6,5 @@ snippet::io.micronaut.rabbitmq.ChannelPoolListener[tags="clazz", project-base="d
 
 <1> The class is declared as a singleton so it will be registered with the context
 <2> The class extends an abstract class provided by this library
-<3> The method is implemented that receives a channel to do the initialization
+<3> The method is implemented that receives a channel and the connection name to do the initialization
 <4> Declare a queue or perform any operations desired


### PR DESCRIPTION
This way it will be possible to distinguish between the different connection as the `ChannelInitializer.initialize` method is called once per configured. This is especially relevant in case multiple connections have been configured via `rabbitmq.servers`.