### PR TITLE
Add BOM module to the project

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ jdkapi=https://docs.oracle.com/javase/8/docs/api
 testsrabbit=rabbitmq/src/test/groovy/io/micronaut/configuration/rabbitmq/docs/
 apimicronaut=https://docs.micronaut.io/latest/api/io/micronaut/
 apirabbit=https://rabbitmq.github.io/rabbitmq-java-client/api/current/com/rabbitmq/
+
+org.gradle.caching=true
+org.gradle.jvmargs=-Xmx1g

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ apimicronaut=https://docs.micronaut.io/latest/api/io/micronaut/
 apirabbit=https://rabbitmq.github.io/rabbitmq-java-client/api/current/com/rabbitmq/
 
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx1g
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ apimicronaut=https://docs.micronaut.io/latest/api/io/micronaut/
 apirabbit=https://rabbitmq.github.io/rabbitmq-java-client/api/current/com/rabbitmq/
 
 org.gradle.caching=true
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=1g

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,11 +3,12 @@ awaitility = '4.2.0'
 junit = '5.9.1'
 kotest = '5.3.2'
 kotlin = '1.7.10'
-rabbit = '5.16.0'
+managed-amqp-client = '5.16.0'
 testcontainers = '1.17.5'
 
 [libraries]
-amqp-client = { module = 'com.rabbitmq:amqp-client', version.ref = 'rabbit' }
+managed-amqp-client = { module = 'com.rabbitmq:amqp-client', version.ref = 'managed-amqp-client' }
+
 awaitility = { module = 'org.awaitility:awaitility', version.ref = 'awaitility' }
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' }
 kotest = { module = 'io.kotest:kotest-runner-junit5', version.ref = 'kotest' }

--- a/rabbitmq-bom/build.gradle
+++ b/rabbitmq-bom/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id "io.micronaut.build.internal.bom"
+}
+
+micronautBom {
+    excludeProject.set({ p ->
+        p.path.startsWith(':docs-examples')
+    } as Spec<Project>)
+}

--- a/rabbitmq-bom/build.gradle
+++ b/rabbitmq-bom/build.gradle
@@ -2,6 +2,9 @@ plugins {
     id "io.micronaut.build.internal.bom"
 }
 
+// Required as a workaround to https://github.com/micronaut-projects/micronaut-build/pull/376
+tasks.named("checkVersionCatalogCompatibility") { onlyIf { false } }
+
 micronautBom {
     excludeProject.set({ p ->
         p.path.startsWith(':docs-examples')

--- a/rabbitmq/build.gradle
+++ b/rabbitmq/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     api mn.micronaut.messaging
     api mn.micronaut.inject
-    api libs.amqp.client
+    api libs.managed.amqp.client
 
     implementation mn.reactor
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,20 +11,15 @@ plugins {
 
 rootProject.name = 'rabbitmq-parent'
 
+include 'rabbitmq-bom'
 include 'rabbitmq'
+
 include 'docs-examples:example-groovy'
 include 'docs-examples:example-java'
 include 'docs-examples:example-kotlin'
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
 
-dependencyResolutionManagement {
-    repositories {
-        mavenCentral()
-    }
-    versionCatalogs {
-        mn {
-            from "io.micronaut:micronaut-bom:${providers.gradleProperty('micronautVersion').get()}"
-        }
-    }
+micronautBuild {
+    importMicronautCatalog()
 }


### PR DESCRIPTION
Fixes #388

As amqp-client was an API dependency, I have added it to the managed-dependencies, and renamed the version to match the dependency name