### PR TITLE
fixed a typo in a comment for annotations

### DIFF
--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/annotation/Queue.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/annotation/Queue.java
@@ -71,7 +71,7 @@ public @interface Queue {
     int prefetch() default 0;
 
     /**
-     * @return The number of consumers used to consumer from a queue concurrently
+     * @return The number of consumers used to consume from a queue concurrently
      */
     int numberOfConsumers() default 1;
 


### PR DESCRIPTION
A small contribution.
I am using micronaut-rabbitmq for handling miroservice events. Caught this typo while I was going throw the documentation of the Queue annotation.