### PR TITLE
Infinite Loop When Channels Leak

### DIFF
--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/DefaultChannelPool.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/DefaultChannelPool.java
@@ -82,6 +82,13 @@ public class DefaultChannelPool implements AutoCloseable, ChannelPool {
             channel = channels.poll();
             if (channel == null) {
                 channel = createChannel();
+                // Check that the channel was actually created to avoid infinite loop
+                if (channel == null) {
+                    if (LOG.isWarnEnabled()) {
+                        LOG.warn("Failed to create a new channel");
+                    }
+                    return null;
+                }
             } else if (!channel.isOpen()) {
                 channel = null;
                 totalChannels.decrementAndGet();

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/DefaultChannelPool.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/DefaultChannelPool.java
@@ -84,10 +84,7 @@ public class DefaultChannelPool implements AutoCloseable, ChannelPool {
                 channel = createChannel();
                 // Check that the channel was actually created to avoid infinite loop
                 if (channel == null) {
-                    if (LOG.isWarnEnabled()) {
-                        LOG.warn("Failed to create a new channel");
-                    }
-                    return null;
+                    throw new IOException("Failed to create a new channel");
                 }
             } else if (!channel.isOpen()) {
                 channel = null;

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/DefaultChannelPoolSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/DefaultChannelPoolSpec.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.rabbitmq.connect
 
 import com.rabbitmq.client.Address
-import com.rabbitmq.client.Channel
 import com.rabbitmq.client.DefaultSocketConfigurator
 import com.rabbitmq.client.impl.AMQConnection
 import com.rabbitmq.client.impl.ConnectionParams
@@ -27,10 +26,11 @@ class DefaultChannelPoolSpec extends Specification {
         DefaultChannelPool pool = new DefaultChannelPool("pool-name", connection, new SingleRabbitConnectionFactoryConfig())
 
         and: "try to obtain a channel from the pool"
-        Channel channel = pool.getChannel()
+        pool.getChannel()
 
-        then: "returned channel is null (no infinite loop)"
-        channel == null
+        then: "IO exception is thrown (no infinite loop)"
+        IOException e = thrown()
+        e.message == "Failed to create a new channel"
 
         cleanup: "stop the dummy server"
         server.interrupt()

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/DefaultChannelPoolSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/DefaultChannelPoolSpec.groovy
@@ -1,0 +1,38 @@
+package io.micronaut.rabbitmq.connect
+
+import com.rabbitmq.client.Address
+import com.rabbitmq.client.Channel
+import com.rabbitmq.client.DefaultSocketConfigurator
+import com.rabbitmq.client.impl.AMQConnection
+import com.rabbitmq.client.impl.ConnectionParams
+import com.rabbitmq.client.impl.SocketFrameHandlerFactory
+import io.micronaut.core.io.socket.SocketUtils
+import spock.lang.Specification
+
+import javax.net.SocketFactory
+
+class DefaultChannelPoolSpec extends Specification {
+
+    void "test infinite loop when channels leak"() {
+        given: "dummy server listening to random port"
+        int port = SocketUtils.findAvailableTcpPort()
+        Thread server = new Thread(() -> new ServerSocket(port).accept())
+        server.start()
+
+        when: "new default channel pool"
+        AMQConnection connection = new AMQConnection(
+                (ConnectionParams) [clientProperties: [:]],
+                new SocketFrameHandlerFactory(60, SocketFactory.default, new DefaultSocketConfigurator(), false)
+                        .create(new Address("localhost", port), "test"))
+        DefaultChannelPool pool = new DefaultChannelPool("pool-name", connection, new SingleRabbitConnectionFactoryConfig())
+
+        and: "try to obtain a channel from the pool"
+        Channel channel = pool.getChannel()
+
+        then: "returned channel is null (no infinite loop)"
+        channel == null
+
+        cleanup: "stop the dummy server"
+        server.interrupt()
+    }
+}


### PR DESCRIPTION
Closes #295 

@sdelamo 
Instead of throwing an exception as the issue suggests, the connection pool will return `null`.

[`getChannel`](https://github.com/micronaut-projects/micronaut-rabbitmq/blob/master/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelPool.java#L46) makes no promises about nullability, so I think this should be safe.

Please let me know if you rather throw an `IOException`.