### PR TITLE
Send application events before/after RabbitMQ consumer subscribe to a queue

### DIFF
--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/event/MyStartedEventListener.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/event/MyStartedEventListener.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.rabbitmq.docs.event
+
+import io.micronaut.context.annotation.Requires
+// tag::imports[]
+import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.rabbitmq.event.RabbitConsumerStarted
+import jakarta.inject.Singleton
+// end::imports[]
+
+@Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
+// tag::clazz[]
+@Singleton
+class MyStartedEventListener implements ApplicationEventListener<RabbitConsumerStarted> {
+  @Override
+  void onApplicationEvent(RabbitConsumerStarted event) {
+    System.out.println("RabbitMQ consumer: ${event.source} (method: ${event.method}) just subscribed to: ${event.queue}")
+  }
+}
+// end::clazz[]

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/event/MyStartedEventListener.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/event/MyStartedEventListener.groovy
@@ -5,15 +5,19 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.context.event.ApplicationEventListener
 import io.micronaut.rabbitmq.event.RabbitConsumerStarted
 import jakarta.inject.Singleton
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 // end::imports[]
 
 @Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
 // tag::clazz[]
 @Singleton
 class MyStartedEventListener implements ApplicationEventListener<RabbitConsumerStarted> {
+  private static final Logger LOG = LoggerFactory.getLogger(MyStartingEventListener.class)
   @Override
   void onApplicationEvent(RabbitConsumerStarted event) {
-    System.out.println("RabbitMQ consumer: ${event.source} (method: ${event.method}) just subscribed to: ${event.queue}")
+    LOG.info("RabbitMQ consumer: {} (method: {}) just subscribed to: {}",
+      event.source, event.method, event.queue);
   }
 }
 // end::clazz[]

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/event/MyStartingEventListener.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/event/MyStartingEventListener.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.rabbitmq.docs.event
+
+import io.micronaut.context.annotation.Requires
+// tag::imports[]
+import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.rabbitmq.event.RabbitConsumerStarting
+import jakarta.inject.Singleton
+// end::imports[]
+
+@Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
+// tag::clazz[]
+@Singleton
+class MyStartingEventListener implements ApplicationEventListener<RabbitConsumerStarting> {
+  @Override
+  void onApplicationEvent(RabbitConsumerStarting event) {
+    System.out.println("RabbitMQ consumer: ${event.source} (method: ${event.method}) is subscribing to: ${event.queue}")
+  }
+}
+// end::clazz[]

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/event/MyStartingEventListener.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/event/MyStartingEventListener.groovy
@@ -5,15 +5,19 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.context.event.ApplicationEventListener
 import io.micronaut.rabbitmq.event.RabbitConsumerStarting
 import jakarta.inject.Singleton
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 // end::imports[]
 
 @Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
 // tag::clazz[]
 @Singleton
 class MyStartingEventListener implements ApplicationEventListener<RabbitConsumerStarting> {
+  private static final Logger LOG = LoggerFactory.getLogger(MyStartingEventListener.class)
   @Override
   void onApplicationEvent(RabbitConsumerStarting event) {
-    System.out.println("RabbitMQ consumer: ${event.source} (method: ${event.method}) is subscribing to: ${event.queue}")
+    LOG.info("RabbitMQ consumer: {} (method: {}) is subscribing to: {}",
+      event.source, event.method, event.queue);
   }
 }
 // end::clazz[]

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/event/MyStartedEventListener.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/event/MyStartedEventListener.java
@@ -5,18 +5,19 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.rabbitmq.event.RabbitConsumerStarted;
 import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 // end::imports[]
 
 @Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
 // tag::clazz[]
 @Singleton
 public class MyStartedEventListener implements ApplicationEventListener<RabbitConsumerStarted> {
+  private static final Logger LOG = LoggerFactory.getLogger(MyStartingEventListener.class);
   @Override
   public void onApplicationEvent(RabbitConsumerStarted event) {
-    System.out.println(new StringBuilder()
-        .append("RabbitMQ consumer: " + event.getSource())
-        .append(" (method: " + event.getMethod() + ")")
-        .append(" just subscribed to: " + event.getQueue()));
+    LOG.info("RabbitMQ consumer: {} (method: {}) just subscribed to: {}",
+      event.getSource(), event.getMethod(), event.getQueue());
   }
 }
 // end::clazz[]

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/event/MyStartedEventListener.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/event/MyStartedEventListener.java
@@ -1,0 +1,22 @@
+package io.micronaut.rabbitmq.docs.event;
+
+import io.micronaut.context.annotation.Requires;
+// tag::imports[]
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.rabbitmq.event.RabbitConsumerStarted;
+import jakarta.inject.Singleton;
+// end::imports[]
+
+@Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
+// tag::clazz[]
+@Singleton
+public class MyStartedEventListener implements ApplicationEventListener<RabbitConsumerStarted> {
+  @Override
+  public void onApplicationEvent(RabbitConsumerStarted event) {
+    System.out.println(new StringBuilder()
+        .append("RabbitMQ consumer: " + event.getSource())
+        .append(" (method: " + event.getMethod() + ")")
+        .append(" just subscribed to: " + event.getQueue()));
+  }
+}
+// end::clazz[]

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/event/MyStartingEventListener.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/event/MyStartingEventListener.java
@@ -5,18 +5,19 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.rabbitmq.event.RabbitConsumerStarting;
 import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 // end::imports[]
 
 @Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
 // tag::clazz[]
 @Singleton
 public class MyStartingEventListener implements ApplicationEventListener<RabbitConsumerStarting> {
+  private static final Logger LOG = LoggerFactory.getLogger(MyStartingEventListener.class);
   @Override
   public void onApplicationEvent(RabbitConsumerStarting event) {
-    System.out.println(new StringBuilder()
-        .append("RabbitMQ consumer: " + event.getSource())
-        .append(" (method: " + event.getMethod() + ")")
-        .append(" is subscribing to: " + event.getQueue()));
+    LOG.info("RabbitMQ consumer: {} (method: {}) is subscribing to: {}",
+      event.getSource(), event.getMethod(), event.getQueue());
   }
 }
 // end::clazz[]

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/event/MyStartingEventListener.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/event/MyStartingEventListener.java
@@ -1,0 +1,22 @@
+package io.micronaut.rabbitmq.docs.event;
+
+import io.micronaut.context.annotation.Requires;
+// tag::imports[]
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.rabbitmq.event.RabbitConsumerStarting;
+import jakarta.inject.Singleton;
+// end::imports[]
+
+@Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
+// tag::clazz[]
+@Singleton
+public class MyStartingEventListener implements ApplicationEventListener<RabbitConsumerStarting> {
+  @Override
+  public void onApplicationEvent(RabbitConsumerStarting event) {
+    System.out.println(new StringBuilder()
+        .append("RabbitMQ consumer: " + event.getSource())
+        .append(" (method: " + event.getMethod() + ")")
+        .append(" is subscribing to: " + event.getQueue()));
+  }
+}
+// end::clazz[]

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/event/MyStartedEventListener.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/event/MyStartedEventListener.kt
@@ -1,0 +1,18 @@
+package io.micronaut.rabbitmq.docs.event
+
+import io.micronaut.context.annotation.Requires
+// tag::imports[]
+import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.rabbitmq.event.RabbitConsumerStarted
+import jakarta.inject.Singleton
+// end::imports[]
+
+@Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
+// tag::clazz[]
+@Singleton
+class MyStartedEventListener : ApplicationEventListener<RabbitConsumerStarted> {
+  override fun onApplicationEvent(event: RabbitConsumerStarted) {
+    println("RabbitMQ consumer: ${event.source} (method: ${event.method}) just subscribed to: ${event.queue}")
+  }
+}
+// end::clazz[]

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/event/MyStartedEventListener.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/event/MyStartedEventListener.kt
@@ -5,14 +5,17 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.context.event.ApplicationEventListener
 import io.micronaut.rabbitmq.event.RabbitConsumerStarted
 import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
 // end::imports[]
 
 @Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
 // tag::clazz[]
 @Singleton
 class MyStartedEventListener : ApplicationEventListener<RabbitConsumerStarted> {
+  private val LOG = LoggerFactory.getLogger(javaClass)
   override fun onApplicationEvent(event: RabbitConsumerStarted) {
-    println("RabbitMQ consumer: ${event.source} (method: ${event.method}) just subscribed to: ${event.queue}")
+    LOG.info("RabbitMQ consumer: {} (method: {}) just subscribed to: {}",
+      event.source, event.method, event.queue)
   }
 }
 // end::clazz[]

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/event/MyStartingEventListener.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/event/MyStartingEventListener.kt
@@ -5,14 +5,17 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.context.event.ApplicationEventListener
 import io.micronaut.rabbitmq.event.RabbitConsumerStarting
 import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
 // end::imports[]
 
 @Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
 // tag::clazz[]
 @Singleton
 class MyStartingEventListener : ApplicationEventListener<RabbitConsumerStarting> {
+  private val LOG = LoggerFactory.getLogger(javaClass)
   override fun onApplicationEvent(event: RabbitConsumerStarting) {
-    println("RabbitMQ consumer: ${event.source} (method: ${event.method}) is subscribing to: ${event.queue}")
+    LOG.info("RabbitMQ consumer: {} (method: {}) is subscribing to: {}",
+      event.source, event.method, event.queue)
   }
 }
 // end::clazz[]

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/event/MyStartingEventListener.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/event/MyStartingEventListener.kt
@@ -1,0 +1,18 @@
+package io.micronaut.rabbitmq.docs.event
+
+import io.micronaut.context.annotation.Requires
+// tag::imports[]
+import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.rabbitmq.event.RabbitConsumerStarting
+import jakarta.inject.Singleton
+// end::imports[]
+
+@Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
+// tag::clazz[]
+@Singleton
+class MyStartingEventListener : ApplicationEventListener<RabbitConsumerStarting> {
+  override fun onApplicationEvent(event: RabbitConsumerStarting) {
+    println("RabbitMQ consumer: ${event.source} (method: ${event.method}) is subscribing to: ${event.queue}")
+  }
+}
+// end::clazz[]

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/AbstractRabbitConsumerEvent.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/AbstractRabbitConsumerEvent.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.rabbitmq.event;
 
-import io.micronaut.inject.MethodReference;
-
 /**
  * Abstract class for RabbitMQ consumer events.
  *
@@ -24,7 +22,7 @@ import io.micronaut.inject.MethodReference;
  */
 public abstract class AbstractRabbitConsumerEvent extends AbstractRabbitEvent<Object> {
 
-    private final MethodReference<?, ?> method;
+    private final String method;
     private final String queue;
 
     /**
@@ -34,7 +32,7 @@ public abstract class AbstractRabbitConsumerEvent extends AbstractRabbitEvent<Ob
      * @param method The consumer method
      * @param queue  The name of the queue the consumer subscribes to
      */
-    protected AbstractRabbitConsumerEvent(Object bean, MethodReference<?, ?> method, String queue) {
+    protected AbstractRabbitConsumerEvent(Object bean, String method, String queue) {
         super(bean);
         this.method = method;
         this.queue = queue;
@@ -50,7 +48,7 @@ public abstract class AbstractRabbitConsumerEvent extends AbstractRabbitEvent<Ob
     /**
      * @return The consumer method.
      */
-    public MethodReference<?, ?> getMethod() {
+    public String getMethod() {
         return method;
     }
 }

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/AbstractRabbitConsumerEvent.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/AbstractRabbitConsumerEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.rabbitmq.event;
+
+import io.micronaut.inject.MethodReference;
+
+/**
+ * Abstract class for RabbitMQ consumer events.
+ *
+ * @since 4.1.0
+ */
+public abstract class AbstractRabbitConsumerEvent extends AbstractRabbitEvent<Object> {
+
+    private final MethodReference<?, ?> method;
+    private final String queue;
+
+    /**
+     * Default constructor.
+     *
+     * @param bean   The bean annotated as {@link io.micronaut.rabbitmq.annotation.RabbitListener}
+     * @param method The consumer method
+     * @param queue  The name of the queue the consumer subscribes to
+     */
+    protected AbstractRabbitConsumerEvent(Object bean, MethodReference<?, ?> method, String queue) {
+        super(bean);
+        this.method = method;
+        this.queue = queue;
+    }
+
+    /**
+     * @return The name of the queue the consumer subscribes to.
+     */
+    public String getQueue() {
+        return queue;
+    }
+
+    /**
+     * @return The consumer method.
+     */
+    public MethodReference<?, ?> getMethod() {
+        return method;
+    }
+}

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/AbstractRabbitEvent.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/AbstractRabbitEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.rabbitmq.event;
+
+import io.micronaut.context.event.ApplicationEvent;
+
+/**
+ * Abstract class for RabbitMQ events.
+ *
+ * @param <T> The source type
+ * @since 4.1.0
+ */
+public abstract class AbstractRabbitEvent<T> extends ApplicationEvent {
+
+    /**
+     * Default constructor.
+     *
+     * @param source The source
+     */
+    protected AbstractRabbitEvent(T source) {
+        super(source);
+    }
+
+    @Override
+    public T getSource() {
+        return (T) super.getSource();
+    }
+}

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/RabbitConsumerStarted.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/RabbitConsumerStarted.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.rabbitmq.event;
 
-import io.micronaut.inject.MethodReference;
-
 /**
  * An event fired after a {@link io.micronaut.rabbitmq.annotation.RabbitListener} subscribes to a queue.
  *
@@ -31,7 +29,7 @@ public class RabbitConsumerStarted extends AbstractRabbitConsumerEvent {
      * @param method The consumer method
      * @param queue  The name of the queue the consumer subscribes to
      */
-    public RabbitConsumerStarted(Object bean, MethodReference<?, ?> method, String queue) {
+    public RabbitConsumerStarted(Object bean, String method, String queue) {
         super(bean, method, queue);
     }
 }

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/RabbitConsumerStarted.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/RabbitConsumerStarted.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.rabbitmq.event;
+
+import io.micronaut.inject.MethodReference;
+
+/**
+ * An event fired after a {@link io.micronaut.rabbitmq.annotation.RabbitListener} subscribes to a queue.
+ *
+ * @since 4.1.0
+ */
+public class RabbitConsumerStarted extends AbstractRabbitConsumerEvent {
+
+    /**
+     * Default constructor.
+     *
+     * @param bean   The bean annotated as {@link io.micronaut.rabbitmq.annotation.RabbitListener}
+     * @param method The consumer method
+     * @param queue  The name of the queue the consumer subscribes to
+     */
+    public RabbitConsumerStarted(Object bean, MethodReference<?, ?> method, String queue) {
+        super(bean, method, queue);
+    }
+}

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/RabbitConsumerStarting.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/RabbitConsumerStarting.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.rabbitmq.event;
+
+import io.micronaut.inject.MethodReference;
+
+/**
+ * An event fired before a RabbitMQ consumer subscribes to a queue.
+ *
+ * @since 4.1.0
+ */
+public class RabbitConsumerStarting extends AbstractRabbitConsumerEvent {
+
+    /**
+     * Default constructor.
+     *
+     * @param bean   The bean annotated as {@link io.micronaut.rabbitmq.annotation.RabbitListener}
+     * @param method The consumer method
+     * @param queue  The name of the queue the consumer subscribes to
+     */
+    public RabbitConsumerStarting(Object bean, MethodReference<?, ?> method, String queue) {
+        super(bean, method, queue);
+    }
+}

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/RabbitConsumerStarting.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/event/RabbitConsumerStarting.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.rabbitmq.event;
 
-import io.micronaut.inject.MethodReference;
-
 /**
  * An event fired before a RabbitMQ consumer subscribes to a queue.
  *
@@ -31,7 +29,7 @@ public class RabbitConsumerStarting extends AbstractRabbitConsumerEvent {
      * @param method The consumer method
      * @param queue  The name of the queue the consumer subscribes to
      */
-    public RabbitConsumerStarting(Object bean, MethodReference<?, ?> method, String queue) {
+    public RabbitConsumerStarting(Object bean, String method, String queue) {
         super(bean, method, queue);
     }
 }

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
@@ -52,6 +52,7 @@ import io.micronaut.rabbitmq.exception.RabbitListenerExceptionHandler;
 import io.micronaut.rabbitmq.serdes.RabbitMessageSerDes;
 import io.micronaut.rabbitmq.serdes.RabbitMessageSerDesRegistry;
 import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,6 +105,7 @@ public class RabbitMQConsumerAdvice implements ExecutableMethodProcessor<Queue>,
      * @param channelPools      The channel pools to retrieve channels
      * @since 4.1.0
      */
+    @Inject
     public RabbitMQConsumerAdvice(BeanContext beanContext,
                                   ApplicationEventPublisher<RabbitConsumerStarting> startingPublisher,
                                   ApplicationEventPublisher<RabbitConsumerStarted> startedPublisher,

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
@@ -136,7 +136,7 @@ public class RabbitMQConsumerAdvice implements ExecutableMethodProcessor<Queue>,
      * @param serDesRegistry    The serialization/deserialization registry
      * @param conversionService The service to convert consume argument values
      * @param channelPools      The channel pools to retrieve channels
-     * @deprecated
+     * @deprecated Use @{link {@link RabbitMQConsumerAdvice#RabbitMQConsumerAdvice(BeanContext, ApplicationEventPublisher, ApplicationEventPublisher, RabbitBinderRegistry, RabbitListenerExceptionHandler, RabbitMessageSerDesRegistry, ConversionService, List)}}
      */
     @Deprecated(since = "4.1.0", forRemoval = true)
     public RabbitMQConsumerAdvice(BeanContext beanContext,

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
@@ -29,6 +29,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.bind.BoundExecutable;
 import io.micronaut.core.bind.DefaultExecutableBinder;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
@@ -101,6 +102,7 @@ public class RabbitMQConsumerAdvice implements ExecutableMethodProcessor<Queue>,
      * @param serDesRegistry    The serialization/deserialization registry
      * @param conversionService The service to convert consume argument values
      * @param channelPools      The channel pools to retrieve channels
+     * @since 4.1.0
      */
     public RabbitMQConsumerAdvice(BeanContext beanContext,
                                   ApplicationEventPublisher<RabbitConsumerStarting> startingPublisher,
@@ -121,6 +123,37 @@ public class RabbitMQConsumerAdvice implements ExecutableMethodProcessor<Queue>,
         for (ChannelPool cp: channelPools) {
             this.channelPools.put(cp.getName(), cp);
         }
+    }
+
+    /**
+     * Deprecated constructor.
+     *
+     * @param beanContext       The bean context
+     * @param binderRegistry    The registry to bind arguments to the method
+     * @param exceptionHandler  The exception handler to use if the consumer isn't a handler
+     * @param serDesRegistry    The serialization/deserialization registry
+     * @param conversionService The service to convert consume argument values
+     * @param channelPools      The channel pools to retrieve channels
+     * @deprecated
+     */
+    @Deprecated(since = "4.1.0", forRemoval = true)
+    public RabbitMQConsumerAdvice(BeanContext beanContext,
+        RabbitBinderRegistry binderRegistry,
+        RabbitListenerExceptionHandler exceptionHandler,
+        RabbitMessageSerDesRegistry serDesRegistry,
+        ConversionService conversionService,
+        List<ChannelPool> channelPools) {
+        this(
+            beanContext,
+            beanContext.findBean(Argument.of((Class<ApplicationEventPublisher<RabbitConsumerStarting>>) ((Class) ApplicationEventPublisher.class),
+                Argument.of(RabbitConsumerStarting.class))).orElseThrow(),
+            beanContext.findBean(Argument.of((Class<ApplicationEventPublisher<RabbitConsumerStarted>>) ((Class) ApplicationEventPublisher.class),
+                Argument.of(RabbitConsumerStarted.class))).orElseThrow(),
+            binderRegistry,
+            exceptionHandler,
+            serDesRegistry,
+            conversionService,
+            channelPools);
     }
 
     @Override

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
@@ -210,14 +210,14 @@ public class RabbitMQConsumerAdvice implements ExecutableMethodProcessor<Queue>,
             };
 
             try {
-                eventPublisher.publishEvent(new RabbitConsumerStarting(bean, method, queue));
+                eventPublisher.publishEvent(new RabbitConsumerStarting(bean, method.getMethodName(), queue));
                 for (int idx = 0; idx < numberOfConsumers; idx++) {
                     String consumerTag = methodTag + "[" + idx + "]";
                     LOG.debug("Registering a consumer to queue [{}] with client tag [{}]", queue, consumerTag);
                     consumers.add(new RecoverableConsumerWrapper(queue, consumerTag, executorService,
                             exclusive, arguments, channelPool, prefetch, deliverCallback, autoAcknowledgment));
                 }
-                eventPublisher.publishEvent(new RabbitConsumerStarted(bean, method, queue));
+                eventPublisher.publishEvent(new RabbitConsumerStarted(bean, method.getMethodName(), queue));
             } catch (Throwable e) {
                 handleException(new RabbitListenerException("An error occurred subscribing to a queue", e, bean, null));
             }

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQConsumerAdvice.java
@@ -147,10 +147,8 @@ public class RabbitMQConsumerAdvice implements ExecutableMethodProcessor<Queue>,
         List<ChannelPool> channelPools) {
         this(
             beanContext,
-            beanContext.findBean(Argument.of((Class<ApplicationEventPublisher<RabbitConsumerStarting>>) ((Class) ApplicationEventPublisher.class),
-                Argument.of(RabbitConsumerStarting.class))).orElseThrow(),
-            beanContext.findBean(Argument.of((Class<ApplicationEventPublisher<RabbitConsumerStarted>>) ((Class) ApplicationEventPublisher.class),
-                Argument.of(RabbitConsumerStarted.class))).orElseThrow(),
+            beanContext.getBean(Argument.of(ApplicationEventPublisher.class, RabbitConsumerStarting.class)),
+            beanContext.getBean(Argument.of(ApplicationEventPublisher.class, RabbitConsumerStarted.class)),
             binderRegistry,
             exceptionHandler,
             serDesRegistry,

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/event/RabbitListenerEventsSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/event/RabbitListenerEventsSpec.groovy
@@ -22,30 +22,30 @@ class RabbitListenerEventsSpec extends AbstractRabbitMQTest {
         and: "received one event consumer1/starting"
         MyConsumer1 consumer1 = applicationContext.getBean(MyConsumer1)
         starting.events.grep { it.source == consumer1 }.size() == 1
-        starting.events.any { it.source == consumer1 && it.method.name == 'consumeMessage' && it.queue == 'abc' }
+        starting.events.any { it.source == consumer1 && it.method == 'consumeMessage' && it.queue == 'abc' }
 
         and: "received one event consumer2/starting"
         MyConsumer2 consumer2 = applicationContext.getBean(MyConsumer2)
         starting.events.grep { it.source == consumer2 }.size() == 1
-        starting.events.any { it.source == consumer2 && it.method.name == 'receiveMessage' && it.queue == 'my-queue' }
+        starting.events.any { it.source == consumer2 && it.method == 'receiveMessage' && it.queue == 'my-queue' }
 
         and: "received two events consumer3/starting, one per listener method"
         MyConsumer3 consumer3 = applicationContext.getBean(MyConsumer3)
         starting.events.grep { it.source == consumer3 }.size() == 2
-        starting.events.any { it.source == consumer3 && it.method.name == 'method1' && it.queue == 'simple' }
-        starting.events.any { it.source == consumer3 && it.method.name == 'method2' && it.queue == 'simple' }
+        starting.events.any { it.source == consumer3 && it.method == 'method1' && it.queue == 'simple' }
+        starting.events.any { it.source == consumer3 && it.method == 'method2' && it.queue == 'simple' }
 
         and: "received one event consumer1/started"
         started.events.grep { it.source == consumer1 }.size() == 1
-        started.events.any { it.source == consumer1 && it.method.name == 'consumeMessage' && it.queue == 'abc' }
+        started.events.any { it.source == consumer1 && it.method == 'consumeMessage' && it.queue == 'abc' }
 
         and: "received no event consumer2/started, because 'my-queue' does not exist"
         started.events.grep { it.source == consumer2 }.size() == 0
 
         and: "received two events consumer3/started, one per listener method"
         started.events.grep { it.source == consumer3 }.size() == 2
-        started.events.any { it.source == consumer3 && it.method.name == 'method1' && it.queue == 'simple' }
-        started.events.any { it.source == consumer3 && it.method.name == 'method2' && it.queue == 'simple' }
+        started.events.any { it.source == consumer3 && it.method == 'method1' && it.queue == 'simple' }
+        started.events.any { it.source == consumer3 && it.method == 'method2' && it.queue == 'simple' }
     }
 
     static abstract class MyRabbitEventListener<T extends AbstractRabbitEvent> implements ApplicationEventListener<T> {

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/event/RabbitListenerEventsSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/event/RabbitListenerEventsSpec.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.rabbitmq.event
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.rabbitmq.AbstractRabbitMQTest
+import io.micronaut.rabbitmq.annotation.Queue
+import io.micronaut.rabbitmq.annotation.RabbitListener
+import jakarta.inject.Singleton
+
+class RabbitListenerEventsSpec extends AbstractRabbitMQTest {
+
+    void "test rabbit listener events"() {
+        given: "started application context"
+        startContext()
+
+        expect: "received all expected rabbit events"
+        MyStartingEventListener starting = applicationContext.getBean(MyStartingEventListener)
+        MyStartedEventListener started = applicationContext.getBean(MyStartedEventListener)
+        starting.events.size() == 4
+        started.events.size() == 3
+
+        and: "received one event consumer1/starting"
+        MyConsumer1 consumer1 = applicationContext.getBean(MyConsumer1)
+        starting.events.grep { it.source == consumer1 }.size() == 1
+        starting.events.any { it.source == consumer1 && it.method.name == 'consumeMessage' && it.queue == 'abc' }
+
+        and: "received one event consumer2/starting"
+        MyConsumer2 consumer2 = applicationContext.getBean(MyConsumer2)
+        starting.events.grep { it.source == consumer2 }.size() == 1
+        starting.events.any { it.source == consumer2 && it.method.name == 'receiveMessage' && it.queue == 'my-queue' }
+
+        and: "received two events consumer3/starting, one per listener method"
+        MyConsumer3 consumer3 = applicationContext.getBean(MyConsumer3)
+        starting.events.grep { it.source == consumer3 }.size() == 2
+        starting.events.any { it.source == consumer3 && it.method.name == 'method1' && it.queue == 'simple' }
+        starting.events.any { it.source == consumer3 && it.method.name == 'method2' && it.queue == 'simple' }
+
+        and: "received one event consumer1/started"
+        started.events.grep { it.source == consumer1 }.size() == 1
+        started.events.any { it.source == consumer1 && it.method.name == 'consumeMessage' && it.queue == 'abc' }
+
+        and: "received no event consumer2/started, because 'my-queue' does not exist"
+        started.events.grep { it.source == consumer2 }.size() == 0
+
+        and: "received two events consumer3/started, one per listener method"
+        started.events.grep { it.source == consumer3 }.size() == 2
+        started.events.any { it.source == consumer3 && it.method.name == 'method1' && it.queue == 'simple' }
+        started.events.any { it.source == consumer3 && it.method.name == 'method2' && it.queue == 'simple' }
+    }
+
+    static abstract class MyRabbitEventListener<T extends AbstractRabbitEvent> implements ApplicationEventListener<T> {
+        List<T> events = []
+
+        @Override
+        void onApplicationEvent(T event) {
+            events << event
+        }
+    }
+
+    @Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
+    @Singleton
+    static class MyStartingEventListener extends MyRabbitEventListener<RabbitConsumerStarting> {}
+
+    @Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
+    @Singleton
+    static class MyStartedEventListener extends MyRabbitEventListener<RabbitConsumerStarted> {}
+
+    @Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
+    @RabbitListener
+    static class MyConsumer1 {
+        @Queue("abc")
+        void consumeMessage(byte[] data) {}
+    }
+
+    @Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
+    @RabbitListener
+    static class MyConsumer2 {
+        @Queue("my-queue")
+        void receiveMessage(byte[] data) {}
+    }
+
+    @Requires(property = "spec.name", value = "RabbitListenerEventsSpec")
+    @RabbitListener
+    static class MyConsumer3 {
+        @Queue("simple")
+        void method1(byte[] data) {}
+
+        @Queue("simple")
+        void method2(byte[] data) {}
+    }
+}

--- a/src/main/docs/guide/consumer/consumerEvents.adoc
+++ b/src/main/docs/guide/consumer/consumerEvents.adoc
@@ -1,0 +1,26 @@
+
+Micronaut sends application events whenever a RabbitMQ consumer subscribes to a queue.
+
+- api:io.micronaut.rabbitmq.event.RabbitConsumerStarting[]: It is fired before a consumer subscribes to a queue.
+- api:io.micronaut.rabbitmq.event.RabbitConsumerStarted[]: It is fired after a consumer subscribes to a queue.
+
+[NOTE]
+====
+These events contain the following information:
+
+- `source`: The bean annotated as ann:configuration.rabbitmq.annotation.RabbitListener[].
+- `method`: The consumer method.
+- `queue`: The name of the queue the consumer subscribes to.
+====
+
+.Handling `RabbitConsumerStarting` events
+
+To take any actions right before consumers try to subscribe to a queue, listen to application event api:io.micronaut.rabbitmq.event.RabbitConsumerStarting[]:
+
+snippet::io.micronaut.rabbitmq.docs.event.MyStartingEventListener[tags="imports,clazz", project-base="docs-examples/example"]
+
+.Handling `RabbitConsumerStarted` events
+
+To take any actions right after consumers are subscribed to a queue, listen to application event api:io.micronaut.rabbitmq.event.RabbitConsumerStarted[]:
+
+snippet::io.micronaut.rabbitmq.docs.event.MyStartedEventListener[tags="imports,clazz", project-base="docs-examples/example"]

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -29,6 +29,7 @@ consumer:
     consumerAcknowledge: Acknowledging Messages
   consumerExceptions: Handling Consumer Exceptions
   consumerExecutor: Consumer Execution
+  consumerEvents: Consumer Events
 rpc:
   title: Directly Reply-To (RPC)
   rpcClientSide: Client Side


### PR DESCRIPTION
Closes #423 

Instead of delaying message consumption, we will emit application events so that users can take any necessary actions before/after RabbitMQ consumers subscribe to a queue.
