### PR TITLE
Close connections before ExecutorService

### DIFF
--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/RabbitConnectionFactory.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/RabbitConnectionFactory.java
@@ -96,6 +96,7 @@ public class RabbitConnectionFactory implements BeanPreDestroyEventListener<Exec
     public ExecutorService onPreDestroy(@NonNull BeanPreDestroyEvent<ExecutorService> event) {
         activeConnections.stream().filter(activeConnection ->
             activeConnection.executorService() == event.getBean()).forEach(ActiveConnection::tryClose);
+        activeConnections.removeIf(activeConnection -> !activeConnection.connection().isOpen());
         return event.getBean();
     }
 

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/RabbitConnectionFactory.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/RabbitConnectionFactory.java
@@ -15,24 +15,27 @@
  */
 package io.micronaut.rabbitmq.connect;
 
+import com.rabbitmq.client.Address;
+import com.rabbitmq.client.Connection;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import io.micronaut.context.exceptions.BeanInstantiationException;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
-
-import com.rabbitmq.client.Address;
-import com.rabbitmq.client.Connection;
-import io.micronaut.context.BeanContext;
-import io.micronaut.context.annotation.EachBean;
-import io.micronaut.context.annotation.Factory;
-import io.micronaut.context.exceptions.BeanInstantiationException;
-import io.micronaut.inject.qualifiers.Qualifiers;
-import jakarta.annotation.PreDestroy;
-import jakarta.inject.Singleton;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A factory for creating a connection to RabbitMQ.
@@ -41,7 +44,7 @@ import org.slf4j.LoggerFactory;
  * @since 1.1.0
  */
 @Factory
-public class RabbitConnectionFactory {
+public class RabbitConnectionFactory implements BeanPreDestroyEventListener<ExecutorService> {
     private static final Logger LOG = LoggerFactory.getLogger(RabbitConnectionFactory.class);
     private final ConcurrentLinkedQueue<ActiveConnection> activeConnections = new ConcurrentLinkedQueue<>();
 
@@ -63,7 +66,7 @@ public class RabbitConnectionFactory {
             } else {
                 connection = connectionFactory.newConnection(executorService);
             }
-            activeConnections.add(new ActiveConnection(connection, connectionFactory));
+            activeConnections.add(new ActiveConnection(connection, connectionFactory, executorService));
             return connection;
         } catch (IOException | TimeoutException e) {
             throw new BeanInstantiationException("Error creating connection to RabbitMQ", e);
@@ -76,22 +79,38 @@ public class RabbitConnectionFactory {
     @PreDestroy
     void shutdownConnections() {
         try {
-            for (ActiveConnection activeConnection : activeConnections) {
-                Connection connection = activeConnection.connection();
-                if (connection.isOpen()) {
-                    try {
-                        connection.close(activeConnection.connectionFactory().getShutdownTimeout());
-                    } catch (Exception e) {
-                        LOG.warn("Error closing RabbitMQ connection: " + e.getMessage(), e);
-                    }
-                }
-            }
+            activeConnections.forEach(ActiveConnection::tryClose);
         } finally {
             this.activeConnections.clear();
         }
     }
 
+    /**
+     * Closes active connections associated with the {@link ExecutorService} prior to its removal.
+     *
+     * @param event The bean created event
+     * @return The unmodified {@link ExecutorService} bean
+     */
+    @Override
+    @NonNull
+    public ExecutorService onPreDestroy(@NonNull BeanPreDestroyEvent<ExecutorService> event) {
+        activeConnections.stream().filter(activeConnection ->
+            activeConnection.executorService() == event.getBean()).forEach(ActiveConnection::tryClose);
+        return event.getBean();
+    }
+
     private record ActiveConnection(Connection connection,
-                                    RabbitConnectionFactoryConfig connectionFactory) {
+                                    RabbitConnectionFactoryConfig connectionFactory, ExecutorService executorService) {
+
+        private void tryClose() {
+            Connection connection = connection();
+            if (connection.isOpen()) {
+                try {
+                    connection.close(connectionFactory().getShutdownTimeout());
+                } catch (Exception e) {
+                    LOG.warn("Error closing RabbitMQ connection: " + e.getMessage(), e);
+                }
+            }
+        }
     }
 }

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/ChannelPoolListener.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/ChannelPoolListener.groovy
@@ -24,6 +24,8 @@ class ChannelPoolListener extends ChannelInitializer {
         channel.queueDeclare("boolean", false, false, false, [:])
         channel.queueDeclare("product", false, false, false, [:])
         channel.queueDeclare("rpc", false, false, false, [:])
+        channel.queueDeclare("shutdown-default", false, false, false, [:])
+        channel.queueDeclare("shutdown-custom", false, false, false, [:])
 
         channel.exchangeDeclare("animals", "headers", false)
         channel.queueDeclare("dogs", false, false, false, null)

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/listener/ShutdownExecutorsSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/listener/ShutdownExecutorsSpec.groovy
@@ -1,0 +1,145 @@
+package io.micronaut.rabbitmq.listener
+
+import com.rabbitmq.client.Channel
+import com.rabbitmq.client.Connection
+import com.rabbitmq.client.ConnectionFactory
+import com.rabbitmq.client.Consumer
+import com.rabbitmq.client.ExceptionHandler
+import com.rabbitmq.client.TopologyRecoveryException
+import io.micronaut.context.annotation.Context
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.event.BeanCreatedEvent
+import io.micronaut.context.event.BeanCreatedEventListener
+import io.micronaut.messaging.annotation.MessageBody
+import io.micronaut.rabbitmq.AbstractRabbitMQTest
+import io.micronaut.rabbitmq.annotation.Queue
+import io.micronaut.rabbitmq.annotation.RabbitListener
+import spock.lang.Issue
+
+class ShutdownExecutorsSpec extends AbstractRabbitMQTest {
+
+    void "server can shut down cleanly without exceptions thrown when the default executor is used"() {
+        given:
+        startContext(['rabbitmq.automatic-recovery-enabled':false])
+
+        when:
+        MyDefaultConsumer consumer = applicationContext.getBean(MyDefaultConsumer.class)
+        ConnectionFactoryInterceptor interceptor = applicationContext.getBean(ConnectionFactoryInterceptor.class)
+
+        then:
+        consumer
+        interceptor
+
+        when:
+        applicationContext.stop()
+
+        then:
+        waitFor {
+            assert !applicationContext.isRunning()
+        }
+        !interceptor.exceptionThrown
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-rabbitmq/issues/524')
+    void "server can shut down cleanly without exceptions thrown when custom executor is used"() {
+        given:
+        startContext(['spec.configuration':'custom',
+                      'micronaut.executors.test.type':'fixed',
+                      'micronaut.executors.test.number-of-threads':15,
+                      'rabbitmq.automatic-recovery-enabled':false])
+
+        when:
+        MyConsumer consumer = applicationContext.getBean(MyConsumer.class)
+        ConnectionFactoryInterceptor interceptor = applicationContext.getBean(ConnectionFactoryInterceptor.class)
+
+        then:
+        consumer
+        interceptor
+
+        when:
+        applicationContext.stop()
+
+        then:
+        waitFor {
+            assert !applicationContext.isRunning()
+        }
+        !interceptor.exceptionThrown
+    }
+
+    @Requires(property = "spec.name", value = "ShutdownExecutorsSpec")
+    @RabbitListener
+    static class MyDefaultConsumer {
+
+        @Queue(value = "shutdown-default")
+        void listenOne(@MessageBody String body) {
+            sleep 500
+        }
+    }
+
+    @Requires(property = "spec.name", value = "ShutdownExecutorsSpec")
+    @Requires(property = "spec.configuration", value = "custom")
+    @RabbitListener
+    static class MyConsumer {
+
+        @Queue(value = "shutdown-custom", executor = "test")
+        void listenOne(@MessageBody String body) {
+            sleep 500
+        }
+    }
+}
+
+@Requires(property = "spec.name", value = "ShutdownExecutorsSpec")
+@Context
+class ConnectionFactoryInterceptor implements BeanCreatedEventListener<ConnectionFactory> {
+
+    boolean exceptionThrown = false
+
+    @Override
+    ConnectionFactory onCreated(BeanCreatedEvent<ConnectionFactory> event) {
+        ConnectionFactory connectionFactory = event.getBean();
+        connectionFactory.setExceptionHandler(new ShutdownFailureExceptionHandler())
+        return connectionFactory;
+    }
+
+    class ShutdownFailureExceptionHandler implements ExceptionHandler {
+        @Override
+        void handleUnexpectedConnectionDriverException(Connection conn, Throwable exception) {
+            exceptionThrown = true
+        }
+
+        @Override
+        void handleReturnListenerException(Channel channel, Throwable exception) {
+            exceptionThrown = true
+        }
+
+        @Override
+        void handleConfirmListenerException(Channel channel, Throwable exception) {
+            exceptionThrown = true
+        }
+
+        @Override
+        void handleBlockedListenerException(Connection connection, Throwable exception) {
+            exceptionThrown = true
+        }
+
+        @Override
+        void handleConsumerException(Channel channel, Throwable exception, Consumer consumer, String consumerTag, String methodName) {
+            exceptionThrown = true
+        }
+
+        @Override
+        void handleConnectionRecoveryException(Connection conn, Throwable exception) {
+            exceptionThrown = true
+        }
+
+        @Override
+        void handleChannelRecoveryException(Channel ch, Throwable exception) {
+            exceptionThrown = true
+        }
+
+        @Override
+        void handleTopologyRecoveryException(Connection conn, Channel ch, TopologyRecoveryException exception) {
+            exceptionThrown = true
+        }
+    }
+}


### PR DESCRIPTION
`RabbitConnectionFactory` will ensure that connections get closed before associated `ExecutorService` beans are 
destroyed, as the connections require the `ExecutorService` to still be available to execute various cleanup tasks.

A test is added to test the shutdown behavior with both the default `ExecutorService` and a custom user-defined one.

Fixes #524