### PR TITLE
Fix rabbitmq container deprecations and test code cleanup.

### DIFF
--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQClusterTest.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQClusterTest.groovy
@@ -45,7 +45,6 @@ abstract class AbstractRabbitMQClusterTest extends Specification {
     RabbitMQContainer node3 = new RabbitMQContainer(DockerImageName.parse(DOCKER_IMAGE_NAME))
 
     def setupSpec() {
-
         configureContainer(node1, "rabbitmq1")
                 .waitingFor(Wait.forHealthcheck().withStartupTimeout(Duration.ofMinutes(1)))
                 .start()
@@ -87,7 +86,8 @@ abstract class AbstractRabbitMQClusterTest extends Specification {
                 "spec.name"                  : getClass().simpleName,
                 "rabbitmq.servers.node1.port": node1Port,
                 "rabbitmq.servers.node2.port": node2Port,
-                "rabbitmq.servers.node3.port": node3Port] << additionalConfig
+                "rabbitmq.servers.node3.port": node3Port
+        ] << additionalConfig
 
         log.info("context properties: {}", properties)
         applicationContext = ApplicationContext.run(properties, "test")
@@ -98,7 +98,6 @@ abstract class AbstractRabbitMQClusterTest extends Specification {
     }
 
     private configureContainer(RabbitMQContainer mqContainer, String hostname) {
-
         String rabbitConfigPath = ClassLoader.getSystemResource("rabbit/rabbitmq.conf").path
         log.info("rabbit.conf path: {}", rabbitConfigPath)
 

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQClusterTest.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQClusterTest.groovy
@@ -24,7 +24,7 @@ abstract class AbstractRabbitMQClusterTest extends Specification {
     private static final Logger log = LoggerFactory.getLogger(AbstractRabbitMQClusterTest)
 
     private static final int AMQP_PORT = 5672
-    private static final String DOCKER_IMAGE_NAME = "rabbitmq:3.13.1-management"
+    private static final String DOCKER_IMAGE_NAME = "rabbitmq:$AbstractRabbitMQTest.RABBIT_CONTAINER_VERSION-management"
 
     protected ApplicationContext applicationContext
 

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQClusterTest.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQClusterTest.groovy
@@ -107,7 +107,7 @@ abstract class AbstractRabbitMQClusterTest extends Specification {
 
         mqContainer
                 .withEnv("RABBITMQ_ERLANG_COOKIE", "test-cluster")
-                .withCopyFileToContainer(forHostPath(rabbitConfigPath), "/etc/rabbitmq/rabbitmq.conf")
+                .withRabbitMQConfigSysctl(forHostPath(rabbitConfigPath))
                 .withCopyFileToContainer(forHostPath(rabbitDefinitionsPath), "/etc/rabbitmq/definitions.json")
                 .withNetwork(mqClusterNet)
                 .withLogConsumer(new Slf4jLogConsumer(log).withPrefix(hostname))

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQClusterTest.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQClusterTest.groovy
@@ -24,7 +24,7 @@ abstract class AbstractRabbitMQClusterTest extends Specification {
     private static final Logger log = LoggerFactory.getLogger(AbstractRabbitMQClusterTest)
 
     private static final int AMQP_PORT = 5672
-    private static final String DOCKER_IMAGE_NAME = "rabbitmq:3.8-management"
+    private static final String DOCKER_IMAGE_NAME = "rabbitmq:3.13.1-management"
 
     protected ApplicationContext applicationContext
 

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQTest.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQTest.groovy
@@ -8,8 +8,10 @@ import spock.util.concurrent.PollingConditions
 
 abstract class AbstractRabbitMQTest extends Specification {
 
+    public static String RABBIT_CONTAINER_VERSION = "3.13.1"
+
     static GenericContainer rabbitContainer =
-            new GenericContainer("library/rabbitmq:3.7")
+            new GenericContainer("rabbitmq:" + RABBIT_CONTAINER_VERSION)
                     .withExposedPorts(5672)
                     .waitingFor(new LogMessageWaitStrategy().withRegEx("(?s).*Server startup complete.*"))
 

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQTest.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQTest.groovy
@@ -1,8 +1,9 @@
 package io.micronaut.rabbitmq
 
 import io.micronaut.context.ApplicationContext
-import org.testcontainers.containers.GenericContainer
-import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
+import org.testcontainers.containers.RabbitMQContainer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -10,12 +11,11 @@ abstract class AbstractRabbitMQTest extends Specification {
 
     static String RABBIT_CONTAINER_VERSION = "3.13.1"
 
-    static GenericContainer rabbitContainer =
-            new GenericContainer("rabbitmq:" + RABBIT_CONTAINER_VERSION)
-                    .withExposedPorts(5672)
-                    .waitingFor(new LogMessageWaitStrategy().withRegEx("(?s).*Server startup complete.*"))
+    @Shared
+    @AutoCleanup
+    RabbitMQContainer rabbitContainer = new RabbitMQContainer("rabbitmq:" + RABBIT_CONTAINER_VERSION)
 
-    static {
+    def setupSpec() {
         rabbitContainer.start()
     }
 

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQTest.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/AbstractRabbitMQTest.groovy
@@ -8,7 +8,7 @@ import spock.util.concurrent.PollingConditions
 
 abstract class AbstractRabbitMQTest extends Specification {
 
-    public static String RABBIT_CONTAINER_VERSION = "3.13.1"
+    static String RABBIT_CONTAINER_VERSION = "3.13.1"
 
     static GenericContainer rabbitContainer =
             new GenericContainer("rabbitmq:" + RABBIT_CONTAINER_VERSION)

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/MultipleServersSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/MultipleServersSpec.groovy
@@ -3,8 +3,8 @@ package io.micronaut.rabbitmq.connect
 import com.rabbitmq.client.Connection
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.qualifiers.Qualifiers
-import org.testcontainers.containers.GenericContainer
-import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
+import io.micronaut.rabbitmq.AbstractRabbitMQTest
+import org.testcontainers.containers.RabbitMQContainer
 import spock.lang.Specification
 
 import java.time.Duration
@@ -13,24 +13,21 @@ class MultipleServersSpec extends Specification {
 
     void "test multiple server configuration"() {
         given:
-        GenericContainer rabbit1 = new GenericContainer("library/rabbitmq:3.7")
-                .withExposedPorts(5672)
-                .waitingFor(new LogMessageWaitStrategy().withRegEx("(?s).*Server startup complete.*"))
-        GenericContainer rabbit2 = new GenericContainer("library/rabbitmq:3.7")
-                .withExposedPorts(5672)
-                .waitingFor(new LogMessageWaitStrategy().withRegEx("(?s).*Server startup complete.*"))
+        RabbitMQContainer rabbit1 = new RabbitMQContainer("rabbitmq:" + AbstractRabbitMQTest.RABBIT_CONTAINER_VERSION)
+        RabbitMQContainer rabbit2 = new RabbitMQContainer("rabbitmq:" + AbstractRabbitMQTest.RABBIT_CONTAINER_VERSION)
 
         when:
         rabbit1.start()
         rabbit2.start()
-        ApplicationContext context = ApplicationContext.run(
-                ["spec.name": getClass().simpleName,
-                 "rabbitmq.servers.one.uri": "amqp://localhost:${rabbit1.getMappedPort(5672)}",
-                 "rabbitmq.servers.one.channel-pool.max-idle-channels": "10",
-                 "rabbitmq.servers.one.rpc.timeout": "10s",
-                 "rabbitmq.servers.two.uri": "amqp://localhost:${rabbit2.getMappedPort(5672)}",
-                 "rabbitmq.servers.two.channel-pool.max-idle-channels": "20",
-                 "rabbitmq.servers.two.rpc.timeout": "20s"])
+        ApplicationContext context = ApplicationContext.run([
+                "spec.name"                                          : getClass().simpleName,
+                "rabbitmq.servers.one.uri"                           : "amqp://localhost:${rabbit1.getMappedPort(5672)}",
+                "rabbitmq.servers.one.channel-pool.max-idle-channels": "10",
+                "rabbitmq.servers.one.rpc.timeout"                   : "10s",
+                "rabbitmq.servers.two.uri"                           : "amqp://localhost:${rabbit2.getMappedPort(5672)}",
+                "rabbitmq.servers.two.channel-pool.max-idle-channels": "20",
+                "rabbitmq.servers.two.rpc.timeout"                   : "20s"
+        ])
 
         then:
         context.getBean(RabbitConnectionFactoryConfig, Qualifiers.byName("one")).port == rabbit1.getMappedPort(5672)

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/TemporarilyDownConsumersSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/TemporarilyDownConsumersSpec.groovy
@@ -21,7 +21,7 @@ import spock.util.concurrent.PollingConditions
 
 class TemporarilyDownConsumersSpec extends Specification {
 
-    static PollingConditions conditions = new PollingConditions(timeout: 10)
+    PollingConditions conditions = new PollingConditions(timeout: 10)
 
     void "test temporarily down consumer"() {
         given:

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/health/RabbitHealthIndicatorSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/health/RabbitHealthIndicatorSpec.groovy
@@ -20,7 +20,7 @@ class RabbitHealthIndicatorSpec extends AbstractRabbitMQTest {
 
         then:
         result.status == UP
-        ((Map<String, Object>) result.details).version.toString().startsWith("3.7")
+        ((Map<String, Object>) result.details).version.toString() == RABBIT_CONTAINER_VERSION
     }
 
     void "test rabbitmq health indicator with 2 connections"() {
@@ -37,8 +37,8 @@ class RabbitHealthIndicatorSpec extends AbstractRabbitMQTest {
         then:
         result.status == UP
         Map<String, List> details = result.details
-        details.get("connections")[0].get("version").toString().startsWith("3.7")
-        details.get("connections")[1].get("version").toString().startsWith("3.7")
+        details.get("connections")[0].get("version").toString() == RABBIT_CONTAINER_VERSION
+        details.get("connections")[1].get("version").toString() == RABBIT_CONTAINER_VERSION
     }
 
     void "test rabbitmq health indicator shows down"() {

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/listener/ConsumerRecoverySpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/listener/ConsumerRecoverySpec.groovy
@@ -219,7 +219,7 @@ class ConsumerRecoverySpec extends AbstractRabbitMQClusterTest {
         container.execInContainer("rabbitmqctl", "start_app")
 
         new PollingConditions(timeout: 60).eventually {
-            container.isHealthy()
+            assert container.isHealthy()
         }
         log.info("started container: {}", container.containerId)
     }

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/listener/ConsumerRecoverySpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/listener/ConsumerRecoverySpec.groovy
@@ -31,6 +31,9 @@ class ConsumerRecoverySpec extends AbstractRabbitMQClusterTest {
 
     private static final Logger log = LoggerFactory.getLogger(ConsumerRecoverySpec)
 
+    static final String EXCHANGE = "test-exchange"
+    static final String QUEUE = "test-durable-queue"
+
     @Shared
     private ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor()
 
@@ -42,7 +45,7 @@ class ConsumerRecoverySpec extends AbstractRabbitMQClusterTest {
 
     def setupSpec() {
         /*
-         * The current Micronaut publisher implementation has a flaw in detecting unroutable drop/return messages
+         * The current Micronaut publisher implementation has a flaw in detecting non-routable drop/return messages
          * in a Rabbit cluster setup. It considers the messages as published even if the broker did not enqueue it.
          * So for this test a simple custom publisher is used that detects unpublished messages.
          */
@@ -232,7 +235,7 @@ class ConsumerRecoverySpec extends AbstractRabbitMQClusterTest {
 
         RabbitListenerException lastException
 
-        @Queue(AbstractRabbitMQClusterTest.QUEUE)
+        @Queue(QUEUE)
         void handleMessage(@MessageBody String body) {
             consumedMessages << body
             log.info("{} received: {}", consumedMessages.size(), body)

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/listener/ConsumerRecoverySpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/listener/ConsumerRecoverySpec.groovy
@@ -24,8 +24,6 @@ import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeoutException
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
-import static org.hamcrest.MatcherAssert.assertThat
-import static org.hamcrest.Matchers.equalTo
 
 class ConsumerRecoverySpec extends AbstractRabbitMQClusterTest {
 
@@ -211,8 +209,7 @@ class ConsumerRecoverySpec extends AbstractRabbitMQClusterTest {
         enablePublisher = false
 
         new PollingConditions(timeout: 60).eventually {
-            assertThat "all published messages must be consumed",
-                    publishedMessages, equalTo(consumer.consumedMessages)
+            assert publishedMessages == consumer.consumedMessages
         }
     }
 


### PR DESCRIPTION
Changes to support using RabbitMQ Docker containers newer than 3.8

closes #594