### PR TITLE
Remove test resources dependency from rabbitMQ

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.rabbitmq-examples.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.rabbitmq-examples.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'io.micronaut.build.internal.rabbitmq-base'
     id "io.micronaut.minimal.application"
-    id "io.micronaut.test-resources"
 }
 
 dependencies {
@@ -10,7 +9,6 @@ dependencies {
     testImplementation mnSerde.micronaut.serde.support
     testImplementation mnSerde.micronaut.serde.jackson
     testImplementation libs.awaitility
-    testImplementation 'io.micronaut.testresources:micronaut-test-resources-client'
 }
 configurations.all {
     resolutionStrategy.dependencySubstitution {
@@ -20,8 +18,4 @@ configurations.all {
 micronaut {
     version libs.versions.micronaut.platform.get()
     testRuntime "junit5"
-    testResources {
-        clientTimeout = 300
-        additionalModules.add(RABBITMQ)
-    }
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.rabbitmq-examples.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.rabbitmq-examples.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
+    testImplementation(project(":test-suite-utils"))
     testImplementation projects.micronautRabbitmq
     testImplementation mn.reactor
     testImplementation mnSerde.micronaut.serde.support

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/acknowledge/type/AcknowledgeSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/acknowledge/type/AcknowledgeSpec.groovy
@@ -2,15 +2,20 @@ package io.micronaut.rabbitmq.docs.consumer.acknowledge.type
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
-
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
 
 @MicronautTest
 @Property(name = "spec.name", value = "AcknowledgeSpec")
-class AcknowledgeSpec extends Specification {
+class AcknowledgeSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties();
+    }
 
     @Inject ProductClient productClient
     @Inject ProductListener productListener

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/concurrent/ConcurrentSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/concurrent/ConcurrentSpec.groovy
@@ -2,16 +2,21 @@ package io.micronaut.rabbitmq.docs.consumer.concurrent
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
-
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "ConcurrentSpec")
-class ConcurrentSpec extends Specification {
+class ConcurrentSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties();
+    }
     @Inject ProductClient productClient
     @Inject ProductListener productListener
 

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/connection/ConnectionSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/connection/ConnectionSpec.groovy
@@ -5,6 +5,7 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
@@ -35,5 +36,14 @@ class ConnectionSpec extends Specification implements TestPropertyProvider {
         cleanup:
         // Finding that the context is closing the channel before ack is sent
         sleep 200
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        Map<String, String> m = new HashMap<>(RabbitMQ.getProperties());
+        String uri = m.get("rabbitmq.uri");
+        String port = String.valueOf(URI.create(uri).getPort());
+        m.put("rabbitmq.servers.product-cluster.port", port);
+        return m;
     }
 }

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/connection/ConnectionSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/connection/ConnectionSpec.groovy
@@ -3,7 +3,6 @@ package io.micronaut.rabbitmq.docs.consumer.connection
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
-import io.micronaut.testresources.client.TestResourcesClientFactory
 import jakarta.inject.Inject
 import spock.lang.Specification
 
@@ -36,14 +35,5 @@ class ConnectionSpec extends Specification implements TestPropertyProvider {
         cleanup:
         // Finding that the context is closing the channel before ack is sent
         sleep 200
-    }
-
-    @Override
-    Map<String, String> getProperties() {
-        var client = TestResourcesClientFactory.fromSystemProperties().get();
-        var rabbitURI = client.resolve("rabbitmq.uri", Map.of(), Map.of());
-        return rabbitURI
-                .map(uri -> Map.of("rabbitmq.servers.product-cluster.port", String.valueOf(URI.create(uri).getPort())))
-                .orElse(Collections.emptyMap());
     }
 }

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/custom/annotation/DeliveryTagSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/custom/annotation/DeliveryTagSpec.groovy
@@ -2,15 +2,22 @@ package io.micronaut.rabbitmq.docs.consumer.custom.annotation
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "DeliveryTagSpec")
-class DeliveryTagSpec extends Specification {
+class DeliveryTagSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties();
+    }
+
     @Inject ProductClient productClient
     @Inject ProductListener productListener
 

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/custom/type/ProductInfoSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/custom/type/ProductInfoSpec.groovy
@@ -2,16 +2,22 @@ package io.micronaut.rabbitmq.docs.consumer.custom.type
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
-
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "ProductInfoSpec")
-class ProductInfoSpec extends Specification {
+class ProductInfoSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties();
+    }
+
     @Inject ProductClient productClient
     @Inject ProductListener productListener
 

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/executor/CustomExecutorSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/executor/CustomExecutorSpec.groovy
@@ -2,16 +2,22 @@ package io.micronaut.rabbitmq.docs.consumer.executor
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest(rebuildContext = true)
 @Property(name = "spec.name", value = "CustomExecutorSpec")
 @Property(name = "micronaut.executors.product-listener.type", value = "FIXED")
-class CustomExecutorSpec extends Specification {
+class CustomExecutorSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties();
+    }
 
     @Inject ProductClient productClient
     @Inject ProductListener productListener

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/types/TypeBindingSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/consumer/types/TypeBindingSpec.groovy
@@ -2,16 +2,22 @@ package io.micronaut.rabbitmq.docs.consumer.types
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
-
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "TypeBindingSpec")
-class TypeBindingSpec extends Specification {
+class TypeBindingSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties();
+    }
+
     @Inject ProductClient productClient
     @Inject ProductListener productListener
 

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/exchange/CustomExchangeSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/exchange/CustomExchangeSpec.groovy
@@ -2,16 +2,21 @@ package io.micronaut.rabbitmq.docs.exchange
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
-
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "CustomExchangeSpec")
-class CustomExchangeSpec extends Specification {
+class CustomExchangeSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties();
+    }
 
     @Inject AnimalClient client
     @Inject AnimalListener listener

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/headers/HeadersSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/headers/HeadersSpec.groovy
@@ -2,16 +2,22 @@ package io.micronaut.rabbitmq.docs.headers
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
-
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "HeadersSpec")
-class HeadersSpec extends Specification {
+class HeadersSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties();
+    }
+
     @Inject ProductClient productClient
     @Inject ProductListener productListener
 

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/parameters/BindingSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/parameters/BindingSpec.groovy
@@ -2,16 +2,22 @@ package io.micronaut.rabbitmq.docs.parameters
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
-
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "BindingSpec")
-class BindingSpec extends Specification {
+class BindingSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties();
+    }
+
     @Inject ProductClient productClient
     @Inject ProductListener productListener
 

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/properties/PropertiesSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/properties/PropertiesSpec.groovy
@@ -2,15 +2,22 @@ package io.micronaut.rabbitmq.docs.properties
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
 
 @MicronautTest
 @Property(name = "spec.name", value = "PropertiesSpec")
-class PropertiesSpec extends Specification {
+class PropertiesSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties();
+    }
+
     @Inject ProductClient productClient
     @Inject ProductListener productListener
 

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/publisher/acknowledge/PublisherAcknowledgeSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/publisher/acknowledge/PublisherAcknowledgeSpec.groovy
@@ -2,11 +2,13 @@ package io.micronaut.rabbitmq.docs.publisher.acknowledge
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import spock.lang.Specification
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicInteger
@@ -16,7 +18,12 @@ import static org.awaitility.Awaitility.await
 
 @MicronautTest
 @Property(name = "spec.name", value = "PublisherAcknowledgeSpec")
-class PublisherAcknowledgeSpec extends Specification {
+class PublisherAcknowledgeSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties()
+    }
+
     @Inject ProductClient productClient
     void "test publisher acknowledgement"() {
         given:

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/quickstart/QuickstartSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/quickstart/QuickstartSpec.groovy
@@ -2,16 +2,23 @@ package io.micronaut.rabbitmq.docs.quickstart
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
 
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "QuickstartSpec")
-class QuickstartSpec extends Specification {
+class QuickstartSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties()
+    }
+
     @Inject ProductClient productClient
     @Inject ProductListener productListener
 

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/rpc/RpcUppercaseSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/rpc/RpcUppercaseSpec.groovy
@@ -2,13 +2,20 @@ package io.micronaut.rabbitmq.docs.rpc
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import reactor.core.publisher.Mono
 import spock.lang.Specification
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "RpcUppercaseSpec")
-class RpcUppercaseSpec extends Specification {
+class RpcUppercaseSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties();
+    }
+
     @Inject ProductClient productClient
 
     void "test product client and listener"() {

--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/serdes/ProductInfoSerDesSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/rabbitmq/docs/serdes/ProductInfoSerDesSpec.groovy
@@ -2,15 +2,22 @@ package io.micronaut.rabbitmq.docs.serdes
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "ProductInfoSerDesSpec")
-class ProductInfoSerDesSpec extends Specification {
+class ProductInfoSerDesSpec extends Specification implements TestPropertyProvider {
+    @Override
+    Map<String, String> getProperties() {
+        RabbitMQ.getProperties();
+    }
+
     @Inject
     ProductClient productClient
     @Inject

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/acknowledge/type/AcknowledgeSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/acknowledge/type/AcknowledgeSpec.java
@@ -2,14 +2,24 @@ package io.micronaut.rabbitmq.docs.consumer.acknowledge.type;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Map;
 
 @MicronautTest
 @Property(name = "spec.name", value = "AcknowledgeSpec")
-class AcknowledgeSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AcknowledgeSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testAckingWithAcknowledgement(ProductClient productClient, ProductListener productListener) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/concurrent/ConcurrentSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/concurrent/ConcurrentSpec.java
@@ -2,14 +2,24 @@ package io.micronaut.rabbitmq.docs.consumer.concurrent;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
+import org.junit.jupiter.api.TestInstance;
 
 @MicronautTest
 @Property(name = "spec.name", value = "ConcurrentSpec")
-class ConcurrentSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ConcurrentSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testConcurrentConsumers(ProductClient productClient, ProductListener productListener) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/connection/ConnectionSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/connection/ConnectionSpec.java
@@ -1,13 +1,13 @@
 package io.micronaut.rabbitmq.docs.consumer.connection;
 
 import java.net.URI;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import io.micronaut.context.annotation.Property;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.micronaut.test.support.TestPropertyProvider;
-import io.micronaut.testresources.client.TestResourcesClientFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -34,10 +34,10 @@ productClient.send("connection-test".getBytes());
 
     @Override
     public Map<String, String> getProperties() {
-        var client = TestResourcesClientFactory.fromSystemProperties().get();
-        var rabbitURI = client.resolve("rabbitmq.uri", Map.of(), Map.of());
-        return rabbitURI
-            .map(uri -> Map.of("rabbitmq.servers.product-cluster.port", String.valueOf(URI.create(uri).getPort())))
-            .orElse(Collections.emptyMap());
+        Map<String, String> m = new HashMap<>(RabbitMQ.getProperties());
+        String uri = m.get("rabbitmq.uri");
+        String port = String.valueOf(URI.create(uri).getPort());
+        m.put("rabbitmq.servers.product-cluster.port", port);
+        return m;
     }
 }

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/custom/annotation/DeliveryTagSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/custom/annotation/DeliveryTagSpec.java
@@ -2,14 +2,24 @@ package io.micronaut.rabbitmq.docs.consumer.custom.annotation;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Map;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
 
 @MicronautTest
 @Property(name = "spec.name", value = "DeliveryTagSpec")
-class DeliveryTagSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DeliveryTagSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testUsingACustomAnnotationBinder(ProductClient productClient, ProductListener productListener) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/custom/type/ProductInfoSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/custom/type/ProductInfoSpec.java
@@ -2,14 +2,24 @@ package io.micronaut.rabbitmq.docs.consumer.custom.type;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
+import org.junit.jupiter.api.TestInstance;
 
 @MicronautTest
 @Property(name = "spec.name", value = "ProductInfoSpec")
-class ProductInfoSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProductInfoSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testUsingACustomTypeBinder(ProductClient productClient, ProductListener productListener) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/executor/CustomExecutorSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/executor/CustomExecutorSpec.java
@@ -4,17 +4,24 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
 
 @MicronautTest(rebuildContext = true)
 @Property(name = "spec.name", value = "CustomExecutorSpec")
 @Property(name = "micronaut.executors.product-listener.type", value = "FIXED")
-class CustomExecutorSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CustomExecutorSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testProductClientAndListener(ProductClient productClient, ProductListener productListener) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/types/TypeBindingSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/consumer/types/TypeBindingSpec.java
@@ -2,14 +2,24 @@ package io.micronaut.rabbitmq.docs.consumer.types;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Map;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
 
 @MicronautTest
 @Property(name = "spec.name", value = "TypeBindingSpec")
-class TypeBindingSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TypeBindingSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testBindingByType(ProductClient productClient, ProductListener productListener) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/exchange/CustomExchangeSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/exchange/CustomExchangeSpec.java
@@ -2,14 +2,24 @@ package io.micronaut.rabbitmq.docs.exchange;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Map;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
 
 @MicronautTest
 @Property(name = "spec.name", value = "CustomExchangeSpec")
-class CustomExchangeSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CustomExchangeSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testUsingACustomExchange(AnimalClient client, AnimalListener listener) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/headers/HeadersSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/headers/HeadersSpec.java
@@ -2,8 +2,10 @@ package io.micronaut.rabbitmq.docs.headers;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.TestInstance;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -12,7 +14,12 @@ import static org.awaitility.Awaitility.await;
 
 @MicronautTest
 @Property(name = "spec.name", value = "HeadersSpec")
-class HeadersSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HeadersSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testPublishingAndReceivingHeaders(ProductClient productClient, ProductListener productListener) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/parameters/BindingSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/parameters/BindingSpec.java
@@ -2,14 +2,23 @@ package io.micronaut.rabbitmq.docs.parameters;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
+import java.util.Map;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
 @MicronautTest
 @Property(name = "spec.name", value = "BindingSpec")
-class BindingSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BindingSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testDynamicBinding(ProductClient productClient, ProductListener productListener) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/properties/PropertiesSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/properties/PropertiesSpec.java
@@ -2,14 +2,24 @@ package io.micronaut.rabbitmq.docs.properties;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Map;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
 
 @MicronautTest
 @Property(name = "spec.name", value = "PropertiesSpec")
-class PropertiesSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PropertiesSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testPublishingAndReceivingProperties(ProductClient productClient, ProductListener productListener) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/publisher/acknowledge/PublisherAcknowledgeSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/publisher/acknowledge/PublisherAcknowledgeSpec.java
@@ -2,20 +2,29 @@ package io.micronaut.rabbitmq.docs.publisher.acknowledge;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
 
 @MicronautTest
 @Property(name = "spec.name", value = "PublisherAcknowledgeSpec")
-class PublisherAcknowledgeSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PublisherAcknowledgeSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testPublisherAcknowledgement(ProductClient productClient) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/quickstart/QuickstartSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/quickstart/QuickstartSpec.java
@@ -2,14 +2,24 @@ package io.micronaut.rabbitmq.docs.quickstart;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
+import org.junit.jupiter.api.TestInstance;
 
 @MicronautTest
 @Property(name = "spec.name", value = "QuickstartSpec")
-class QuickstartSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class QuickstartSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testProductClientAndListener(ProductClient productClient, ProductListener productListener) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/rpc/RpcUppercaseSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/rpc/RpcUppercaseSpec.java
@@ -2,14 +2,24 @@ package io.micronaut.rabbitmq.docs.rpc;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import reactor.core.publisher.Mono;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
 
 @MicronautTest
 @Property(name = "spec.name", value = "RpcUppercaseSpec")
-class RpcUppercaseSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RpcUppercaseSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testProductClientAndListener(ProductClient productClient) {

--- a/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/serdes/ProductInfoSerDesSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/rabbitmq/docs/serdes/ProductInfoSerDesSpec.java
@@ -2,14 +2,24 @@ package io.micronaut.rabbitmq.docs.serdes;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Map;
 
 @MicronautTest
 @Property(name = "spec.name", value = "ProductInfoSerDesSpec")
-class ProductInfoSerDesSpec {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProductInfoSerDesSpec implements TestPropertyProvider {
+    @Override
+    public Map<String, String> getProperties() {
+        return RabbitMQ.getProperties();
+    }
 
     @Test
     void testUsingACustomSerDes(ProductClient productClient, ProductListener productListener) {

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/acknowledge/type/AcknowledgeSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/acknowledge/type/AcknowledgeSpec.kt
@@ -1,33 +1,41 @@
 package io.micronaut.rabbitmq.docs.consumer.acknowledge.type
 
 import io.kotest.assertions.timing.eventually
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import kotlin.time.Duration.Companion.seconds
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "AcknowledgeSpec")
-class AcknowledgeSpec(productClient: ProductClient, productListener: ProductListener) : BehaviorSpec({
+class AcknowledgeSpec : TestPropertyProvider, AnnotationSpec() {
 
-    val specName = javaClass.simpleName
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
 
-    given("An acknowledgement argument") {
-        `when`("The messages are published") {
+    @Inject
+    lateinit var productClient: ProductClient
 
-            // tag::producer[]
-            productClient.send("body".toByteArray())
-            productClient.send("body".toByteArray())
-            productClient.send("body".toByteArray())
-            productClient.send("body".toByteArray())
-            // end::producer[]
+    @Inject
+    lateinit var productListener: ProductListener
 
-            then("The messages are received") {
-                eventually(10.seconds) {
-                    productListener.messageCount.get() shouldBe 5
-                }
-            }
+    @Test
+    suspend fun testAcknowledgementArgument() {
+
+        // tag::producer[]
+        productClient.send("body".toByteArray())
+        productClient.send("body".toByteArray())
+        productClient.send("body".toByteArray())
+        productClient.send("body".toByteArray())
+        // end::producer[]
+
+        eventually(10.seconds) {
+            productListener.messageCount.get() shouldBe 5
         }
     }
-})
+}

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/concurrent/ConcurrentSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/concurrent/ConcurrentSpec.kt
@@ -1,29 +1,37 @@
 package io.micronaut.rabbitmq.docs.consumer.concurrent
 
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.framework.concurrency.eventually
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import kotlin.time.Duration.Companion.seconds
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "ConcurrentSpec")
-class ConcurrentSpec(productClient: ProductClient, productListener: ProductListener) : BehaviorSpec({
+class ConcurrentSpec : TestPropertyProvider, AnnotationSpec() {
 
-    val specName = javaClass.simpleName
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
 
-    given("A basic producer and consumer") {
-        `when`("The messages are published") {
-            for (i in 0..3) {
-                productClient.send("body".toByteArray())
-            }
+    @Inject
+    lateinit var productClient: ProductClient
 
-            then("The messages are received") {
-                eventually(5.seconds) {
-                    productListener.threads.size shouldBe 4
-                }
-            }
+    @Inject
+    lateinit var productListener: ProductListener
+
+    @Test
+    suspend fun testBasicProducerAndConsumer() {
+        for (i in 0..3) {
+            productClient.send("body".toByteArray())
+        }
+
+        eventually(5.seconds) {
+            productListener.threads.size shouldBe 4
         }
     }
-})
+}

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/connection/ConnectionSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/connection/ConnectionSpec.kt
@@ -4,12 +4,11 @@ import io.kotest.assertions.timing.eventually
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
-import io.micronaut.testresources.client.TestResourcesClientFactory
 import jakarta.inject.Inject
 import java.net.URI
-import java.util.Map
 import kotlin.time.Duration.Companion.seconds
 
 @MicronautTest
@@ -32,16 +31,11 @@ class ConnectionSpec
         }
     }
 
-    override fun getProperties(): MutableMap<String, String> {
-        val client = TestResourcesClientFactory.fromSystemProperties().get()
-        val rabbitURI = client.resolve("rabbitmq.uri", Map.of(), Map.of())
-        return rabbitURI
-            .map { uri: String ->
-                Map.of(
-                    "rabbitmq.servers.product-cluster.port",
-                    URI.create(uri).port.toString()
-                )
-            }
-            .orElse(emptyMap())
+    override fun getProperties(): Map<String, String> {
+        val m: MutableMap<String, String> = HashMap(RabbitMQ.getProperties())
+        val uri: String = m["rabbitmq.uri"]!!
+        val port = URI.create(uri).port.toString()
+        m["rabbitmq.servers.product-cluster.port"] = port
+        return m
     }
 }

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/custom/annotation/DeliveryTagSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/custom/annotation/DeliveryTagSpec.kt
@@ -1,33 +1,39 @@
 package io.micronaut.rabbitmq.docs.consumer.custom.annotation
 
 import io.kotest.assertions.timing.eventually
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "DeliveryTagSpec")
-class DeliveryTagSpec(productClient: ProductClient, productListener: ProductListener) : BehaviorSpec({
+class DeliveryTagSpec : TestPropertyProvider, AnnotationSpec() {
 
-    val specName = javaClass.simpleName
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
 
-    given("Using a custom annotation binder") {
+    @Inject
+    lateinit var productClient: ProductClient
 
-        `when`("The messages are published") {
-            // tag::producer[]
-            productClient.send("body".toByteArray())
-            productClient.send("body2".toByteArray())
-            productClient.send("body3".toByteArray())
-            // end::producer[]
+    @Inject
+    lateinit var productListener: ProductListener
 
-            then("The messages are received") {
-                eventually(10.seconds) {
-                    productListener.messages.size shouldBe 3
-                }
-            }
+    @Test
+    suspend fun testUsingCustomAnnotationBinder() {
+        // tag::producer[]
+        productClient.send("body".toByteArray())
+        productClient.send("body2".toByteArray())
+        productClient.send("body3".toByteArray())
+        // end::producer[]
+
+        eventually(10.seconds) {
+            productListener.messages.size shouldBe 3
         }
     }
-})
+}

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/custom/type/ProductInfoSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/custom/type/ProductInfoSpec.kt
@@ -1,37 +1,44 @@
 package io.micronaut.rabbitmq.docs.consumer.custom.type
 
 import io.kotest.assertions.timing.eventually
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.collections.shouldExist
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "ProductInfoSpec")
-class ProductInfoSpec(productClient: ProductClient, productListener: ProductListener) : BehaviorSpec({
+class ProductInfoSpec : TestPropertyProvider, AnnotationSpec() {
 
-    val specName = javaClass.simpleName
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
 
-    given("A custom type binder") {
-        `when`("The messages are published") {
+    @Inject
+    lateinit var productClient: ProductClient
 
-            // tag::producer[]
-            productClient.send("body".toByteArray())
-            productClient.send("medium", 20L, "body2".toByteArray())
-            productClient.send(null, 30L, "body3".toByteArray())
-            // end::producer[]
+    @Inject
+    lateinit var productListener: ProductListener
 
-            then("The messages are received") {
-                eventually(10.seconds) {
-                    productListener.messages.size shouldBe 3
-                    productListener.messages shouldExist { p -> p.size == "small" && p.count == 10L && p.sealed }
-                    productListener.messages shouldExist { p -> p.size == "medium" && p.count == 20L && p.sealed }
-                    productListener.messages shouldExist { p -> p.size == null && p.count == 30L && p.sealed }
-                }
-            }
+    @Test
+    suspend fun testCustomTypeBinder() {
+
+        // tag::producer[]
+        productClient.send("body".toByteArray())
+        productClient.send("medium", 20L, "body2".toByteArray())
+        productClient.send(null, 30L, "body3".toByteArray())
+        // end::producer[]
+
+        eventually(10.seconds) {
+            productListener.messages.size shouldBe 3
+            productListener.messages shouldExist { p -> p.size == "small" && p.count == 10L && p.sealed }
+            productListener.messages shouldExist { p -> p.size == "medium" && p.count == 20L && p.sealed }
+            productListener.messages shouldExist { p -> p.size == null && p.count == 30L && p.sealed }
         }
     }
-})
+}

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/executor/CustomExecutorSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/executor/CustomExecutorSpec.kt
@@ -2,17 +2,22 @@ package io.micronaut.rabbitmq.docs.consumer.executor
 
 import io.kotest.assertions.timing.eventually
 import io.kotest.core.spec.style.AnnotationSpec
-import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
 @MicronautTest(rebuildContext = true)
 @Property(name = "micronaut.executors.product-listener.type", value = "FIXED")
 @Property(name = "spec.name", value = "CustomExecutorSpec")
-class CustomExecutorSpec : AnnotationSpec() {
+class CustomExecutorSpec : TestPropertyProvider, AnnotationSpec() {
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
+
     @Inject
     lateinit var productClient: ProductClient
 

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/types/TypeBindingSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/consumer/types/TypeBindingSpec.kt
@@ -1,38 +1,44 @@
 package io.micronaut.rabbitmq.docs.consumer.types
 
 import io.kotest.assertions.timing.eventually
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "TypeBindingSpec")
-class TypeBindingSpec(productClient: ProductClient, productListener: ProductListener) : BehaviorSpec({
+class TypeBindingSpec : TestPropertyProvider, AnnotationSpec() {
 
-    val specName = javaClass.simpleName
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
 
-    given("A basic producer and consumer") {
+    @Inject
+    lateinit var productClient: ProductClient
 
-        `when`("The messages are published") {
+    @Inject
+    lateinit var productListener: ProductListener
 
-            // tag::producer[]
-            productClient.send("body".toByteArray(), "text/html")
-            productClient.send("body2".toByteArray(), "application/json")
-            productClient.send("body3".toByteArray(), "text/xml")
-            // end::producer[]
+    @Test
+    suspend fun testBasicProducerAndConsumer() {
 
-            then("The messages are received") {
-                eventually(10.seconds) {
-                    productListener.messages.size shouldBe 3
-                    productListener.messages shouldContain "exchange: [], routingKey: [product], contentType: [text/html]"
-                    productListener.messages shouldContain "exchange: [], routingKey: [product], contentType: [application/json]"
-                    productListener.messages shouldContain "exchange: [], routingKey: [product], contentType: [text/xml]"
-                }
-            }
+        // tag::producer[]
+        productClient.send("body".toByteArray(), "text/html")
+        productClient.send("body2".toByteArray(), "application/json")
+        productClient.send("body3".toByteArray(), "text/xml")
+        // end::producer[]
+
+        eventually(10.seconds) {
+            productListener.messages.size shouldBe 3
+            productListener.messages shouldContain "exchange: [], routingKey: [product], contentType: [text/html]"
+            productListener.messages shouldContain "exchange: [], routingKey: [product], contentType: [application/json]"
+            productListener.messages shouldContain "exchange: [], routingKey: [product], contentType: [text/xml]"
         }
     }
-})
+}

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/exchange/CustomExchangeSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/exchange/CustomExchangeSpec.kt
@@ -1,45 +1,52 @@
 package io.micronaut.rabbitmq.docs.exchange
 
 import io.kotest.assertions.timing.eventually
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.collections.shouldExist
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "CustomExchangeSpec")
-class CustomExchangeSpec(client: AnimalClient, listener: AnimalListener): BehaviorSpec({
+class CustomExchangeSpec : TestPropertyProvider, AnnotationSpec() {
 
-    val specName = javaClass.simpleName
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
 
-    given("Using a custom exchange") {
-        `when`("the messages are published") {
-            client.send(Cat("Whiskers", 9))
-            client.send(Cat("Mr. Bigglesworth", 8))
-            client.send(Snake("Buttercup", false))
-            client.send(Snake("Monty the Python", true))
+    @Inject
+    lateinit var client: AnimalClient
 
-            then("the messages are received") {
-                val messages = listener.receivedAnimals
-                eventually(10.seconds) {
-                    messages.size shouldBe  4
-                    messages shouldExist({ animal: Animal ->
-                        Cat::class.isInstance(animal) && animal.name == "Whiskers"
-                    })
-                    messages shouldExist({ animal: Animal ->
-                        Cat::class.isInstance(animal) && animal.name == "Mr. Bigglesworth"
-                    })
-                    messages shouldExist({ animal: Animal ->
-                        Snake::class.isInstance(animal) && animal.name == "Buttercup"
-                    })
-                    messages shouldExist({ animal: Animal ->
-                        Snake::class.isInstance(animal) && animal.name == "Monty the Python"
-                    })
-                }
-            }
+    @Inject
+    lateinit var listener: AnimalListener
+
+    @Test
+    suspend fun testUsingCustomExchange() {
+        client.send(Cat("Whiskers", 9))
+        client.send(Cat("Mr. Bigglesworth", 8))
+        client.send(Snake("Buttercup", false))
+        client.send(Snake("Monty the Python", true))
+
+        val messages = listener.receivedAnimals
+        eventually(10.seconds) {
+            messages.size shouldBe  4
+            messages shouldExist({ animal: Animal ->
+                Cat::class.isInstance(animal) && animal.name == "Whiskers"
+            })
+            messages shouldExist({ animal: Animal ->
+                Cat::class.isInstance(animal) && animal.name == "Mr. Bigglesworth"
+            })
+            messages shouldExist({ animal: Animal ->
+                Snake::class.isInstance(animal) && animal.name == "Buttercup"
+            })
+            messages shouldExist({ animal: Animal ->
+                Snake::class.isInstance(animal) && animal.name == "Monty the Python"
+            })
         }
     }
-})
+}

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/headers/HeadersSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/headers/HeadersSpec.kt
@@ -1,37 +1,46 @@
 package io.micronaut.rabbitmq.docs.headers
 
 import io.kotest.assertions.timing.eventually
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "HeadersSpec")
-class HeadersSpec(productClient: ProductClient, productListener: ProductListener) : BehaviorSpec({
+class HeadersSpec : TestPropertyProvider, AnnotationSpec() {
 
-    given("A basic producer and consumer") {
-        `when`("The messages are published") {
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
 
-            // tag::producer[]
-            productClient.send("body".toByteArray())
-            productClient.send("medium", 20L, "body2".toByteArray())
-            productClient.send(null, 30L, "body3".toByteArray())
-            productClient.send(mapOf<String, Any>("productSize" to "large", "x-product-count" to 40L), "body4".toByteArray())
-            // end::producer[]
+    @Inject
+    lateinit var productClient: ProductClient
 
-            then("The messages are received") {
-                eventually(10.seconds) {
-                    productListener.messageProperties.size shouldBe 4
-                    productListener.messageProperties shouldContain "true|10|small"
-                    productListener.messageProperties shouldContain "true|20|medium"
-                    productListener.messageProperties shouldContain "true|30|null"
-                    productListener.messageProperties shouldContain "true|40|large"
-                }
-            }
+    @Inject
+    lateinit var productListener: ProductListener
+
+    @Test
+    suspend fun testBasicProducerAndConsumer() {
+
+        // tag::producer[]
+        productClient.send("body".toByteArray())
+        productClient.send("medium", 20L, "body2".toByteArray())
+        productClient.send(null, 30L, "body3".toByteArray())
+        productClient.send(mapOf<String, Any>("productSize" to "large", "x-product-count" to 40L), "body4".toByteArray())
+        // end::producer[]
+
+        eventually(10.seconds) {
+            productListener.messageProperties.size shouldBe 4
+            productListener.messageProperties shouldContain "true|10|small"
+            productListener.messageProperties shouldContain "true|20|medium"
+            productListener.messageProperties shouldContain "true|30|null"
+            productListener.messageProperties shouldContain "true|40|large"
         }
     }
-})
+}

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/parameters/BindingSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/parameters/BindingSpec.kt
@@ -1,33 +1,42 @@
 package io.micronaut.rabbitmq.docs.parameters
 
 import io.kotest.assertions.timing.eventually
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "BindingSpec")
-class BindingSpec(productClient: ProductClient, productListener: ProductListener): BehaviorSpec({
+class BindingSpec : TestPropertyProvider, AnnotationSpec() {
 
-    given("A basic producer and consumer") {
-        `when`("The messages are published") {
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
 
-            // tag::producer[]
-            productClient.send("message body".toByteArray())
-            productClient.send("product", "message body2".toByteArray())
-            // end::producer[]
+    @Inject
+    lateinit var productClient: ProductClient
 
-            then("The messages are received") {
-                eventually(10.seconds) {
-                    productListener.messageLengths.size shouldBe 2
-                    productListener.messageLengths shouldContain 12
-                    productListener.messageLengths shouldContain 13
-                }
-            }
+    @Inject
+    lateinit var productListener: ProductListener
+
+    @Test
+    suspend fun testBasicProducerAndConsumer() {
+
+        // tag::producer[]
+        productClient.send("message body".toByteArray())
+        productClient.send("product", "message body2".toByteArray())
+        // end::producer[]
+
+        eventually(10.seconds) {
+            productListener.messageLengths.size shouldBe 2
+            productListener.messageLengths shouldContain 12
+            productListener.messageLengths shouldContain 13
         }
     }
-})
+}

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/properties/PropertiesSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/properties/PropertiesSpec.kt
@@ -1,35 +1,43 @@
 package io.micronaut.rabbitmq.docs.properties
 
 import io.kotest.assertions.timing.eventually
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "PropertiesSpec")
-class PropertiesSpec(productClient: ProductClient, productListener: ProductListener) : BehaviorSpec({
+class PropertiesSpec :TestPropertyProvider, AnnotationSpec() {
 
-    given("publishing and receiving properties") {
-        `when`("messages with properties are sent") {
-            // tag::producer[]
-            productClient.send("body".toByteArray())
-            productClient.send("guest", "text/html", "body2".toByteArray())
-            productClient.send("guest", null, "body3".toByteArray())
-            // end::producer[]
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
 
-            then("the messages are received") {
+    @Inject
+    lateinit var productClient: ProductClient
 
-                eventually(10.seconds) {
-                    productListener.messageProperties.size shouldBe 3
-                    productListener.messageProperties shouldContain "guest|application/json|myApp"
-                    productListener.messageProperties shouldContain "guest|text/html|myApp"
-                    productListener.messageProperties shouldContain "guest|null|myApp"
-                }
-            }
+    @Inject
+    lateinit var productListener: ProductListener
+
+    @Test
+    suspend fun testPublishingAndReceivingProperties() {
+        // tag::producer[]
+        productClient.send("body".toByteArray())
+        productClient.send("guest", "text/html", "body2".toByteArray())
+        productClient.send("guest", null, "body3".toByteArray())
+        // end::producer[]
+
+        eventually(10.seconds) {
+            productListener.messageProperties.size shouldBe 3
+            productListener.messageProperties shouldContain "guest|application/json|myApp"
+            productListener.messageProperties shouldContain "guest|text/html|myApp"
+            productListener.messageProperties shouldContain "guest|null|myApp"
         }
     }
-})
+}

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/publisher/acknowledge/PublisherAcknowledgeSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/publisher/acknowledge/PublisherAcknowledgeSpec.kt
@@ -1,72 +1,81 @@
 package io.micronaut.rabbitmq.docs.publisher.acknowledge;
 
 import io.kotest.assertions.timing.eventually
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.seconds
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "PublisherAcknowledgeSpec")
-class PublisherAcknowledgeSpec(productClient: ProductClient) : BehaviorSpec({
+class PublisherAcknowledgeSpec : TestPropertyProvider, AnnotationSpec() {
 
-    given("Publisher acknowledgement") {
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
+
+    @Inject
+    lateinit var productClient: ProductClient
+
+    @Test
+    suspend fun testPublisherAcknowledgement() = coroutineScope {
         val successCount = AtomicInteger(0)
         val errorCount = AtomicInteger(0)
 
-        `when`("The messages are published") {
-            // tag::producer[]
-            val publisher = productClient.sendPublisher("publisher body".toByteArray())
-            val future = productClient.sendFuture("future body".toByteArray())
-            val deferred = async {
-                productClient.sendSuspend("suspend body".toByteArray())
+        // tag::producer[]
+        val publisher = productClient.sendPublisher("publisher body".toByteArray())
+        val future = productClient.sendFuture("future body".toByteArray())
+        val deferred = async {
+            productClient.sendSuspend("suspend body".toByteArray())
+        }
+
+        val subscriber = (object: Subscriber<Void> {
+            override fun onSubscribe(subscription: Subscription) { }
+
+            override fun onNext(aVoid: Void) {
+                throw UnsupportedOperationException("Should never be called")
             }
 
-            val subscriber = (object: Subscriber<Void> {
-                override fun onSubscribe(subscription: Subscription) { }
-
-                override fun onNext(aVoid: Void) {
-                    throw UnsupportedOperationException("Should never be called")
-                }
-
-                override fun onError(throwable: Throwable) {
-                    // if an error occurs
-                    errorCount.incrementAndGet()
-                }
-
-                override fun onComplete() {
-                    // if the publish was acknowledged
-                    successCount.incrementAndGet()
-                }
-            })
-            publisher.subscribe(subscriber)
-            future.handle { _, t ->
-                if (t == null) {
-                    successCount.incrementAndGet()
-                } else {
-                    errorCount.incrementAndGet()
-                }
+            override fun onError(throwable: Throwable) {
+                // if an error occurs
+                errorCount.incrementAndGet()
             }
-            deferred.invokeOnCompletion {
-                if (it == null) {
-                    successCount.incrementAndGet()
-                } else {
-                    errorCount.incrementAndGet()
-                }
-            }
-// end::producer[]
 
-            then("The messages are published") {
-                eventually(10.seconds) {
-                    errorCount.get() shouldBe 0
-                    successCount.get() shouldBe 3
-                }
+            override fun onComplete() {
+                // if the publish was acknowledged
+                successCount.incrementAndGet()
+            }
+        })
+        publisher.subscribe(subscriber)
+        future.handle { _, t ->
+            if (t == null) {
+                successCount.incrementAndGet()
+            } else {
+                errorCount.incrementAndGet()
             }
         }
+        deferred.invokeOnCompletion {
+            if (it == null) {
+                successCount.incrementAndGet()
+            } else {
+                errorCount.incrementAndGet()
+            }
+        }
+// end::producer[]
+
+        eventually(10.seconds) {
+            errorCount.get() shouldBe 0
+            successCount.get() shouldBe 3
+        }
     }
-})
+
+}

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/quickstart/QuickstartSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/quickstart/QuickstartSpec.kt
@@ -1,30 +1,39 @@
 package io.micronaut.rabbitmq.docs.quickstart
 
 import io.kotest.assertions.timing.eventually
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "QuickstartSpec")
-class QuickstartSpec(productClient: ProductClient, productListener: ProductListener): BehaviorSpec({
+class QuickstartSpec : TestPropertyProvider, AnnotationSpec() {
 
-    given("A basic producer and consumer") {
-        `when`("the message is published") {
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
+
+    @Inject
+    lateinit var productClient: ProductClient
+
+    @Inject
+    lateinit var productListener: ProductListener
+
+    @Test
+    suspend fun testBasicProducerAndConsumer() {
 
 // tag::producer[]
 productClient.send("quickstart".toByteArray())
 // end::producer[]
 
-            then("the message is consumed") {
-                eventually(10.seconds) {
-                    productListener.messageLengths.size shouldBe 1
-                    productListener.messageLengths[0] shouldBe "quickstart"
-                }
-            }
+        eventually(10.seconds) {
+            productListener.messageLengths.size shouldBe 1
+            productListener.messageLengths[0] shouldBe "quickstart"
         }
     }
-})
+}

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/rpc/RpcUppercaseSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/rpc/RpcUppercaseSpec.kt
@@ -1,24 +1,28 @@
 package io.micronaut.rabbitmq.docs.rpc
 
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import reactor.core.publisher.Mono
-import kotlin.time.ExperimentalTime
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "RpcUppercaseSpec")
-class RpcUppercaseSpec(productClient: ProductClient): BehaviorSpec({
+class RpcUppercaseSpec : TestPropertyProvider, AnnotationSpec() {
 
-    val specName = javaClass.simpleName
+    @Inject
+    lateinit var productClient: ProductClient
 
-    given("A basic producer and consumer") {
-        `when`("the message is published") {
-            then("the message is consumed") {
-                productClient.send("hello") shouldBe "HELLO"
-                Mono.from(productClient.sendReactive("world")).block() shouldBe "WORLD"
-            }
-        }
+    @Test
+    fun testRpcUppercase() {
+        productClient.send("hello") shouldBe "HELLO"
+        Mono.from(productClient.sendReactive("world")).block() shouldBe "WORLD"
     }
-})
+
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
+}

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/serdes/ProductInfoSerDesSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/rabbitmq/docs/serdes/ProductInfoSerDesSpec.kt
@@ -1,37 +1,44 @@
 package io.micronaut.rabbitmq.docs.serdes
 
 import io.kotest.assertions.timing.eventually
-import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.collections.shouldExist
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
+import io.micronaut.rabbitmq.testcontainers.RabbitMQ
 
 @MicronautTest
 @Property(name = "spec.name", value = "ProductInfoSerDesSpec")
-class ProductInfoSerDesSpec(productClient: ProductClient, listener: ProductListener): BehaviorSpec({
+class ProductInfoSerDesSpec : TestPropertyProvider, AnnotationSpec() {
 
-    val specName = javaClass.simpleName
+    override fun getProperties(): Map<String, String> {
+        return RabbitMQ.getProperties()
+    }
 
-    given("A basic producer and consumer") {
-        `when`("the message is published") {
+    @Inject
+    lateinit var productClient: ProductClient
+
+    @Inject
+    lateinit var listener: ProductListener
+
+    @Test
+    suspend fun testBasicProducerAndConsumer() {
 
 // tag::producer[]
-            productClient.send(ProductInfo("small", 10L, true))
-            productClient.send(ProductInfo("medium", 20L, true))
-            productClient.send(ProductInfo(null, 30L, false))
+        productClient.send(ProductInfo("small", 10L, true))
+        productClient.send(ProductInfo("medium", 20L, true))
+        productClient.send(ProductInfo(null, 30L, false))
 // end::producer[]
 
-            then("the message is consumed") {
-                eventually(10.seconds) {
-                    listener.messages.size shouldBe 3
-                    listener.messages shouldExist { p -> p.size == "small" && p.count == 10L && p.sealed }
-                    listener.messages shouldExist { p -> p.size == "medium" && p.count == 20L && p.sealed }
-                    listener.messages shouldExist { p -> p.size == null && p.count == 30L && !p.sealed }
-                }
-            }
+        eventually(10.seconds) {
+            listener.messages.size shouldBe 3
+            listener.messages shouldExist { p -> p.size == "small" && p.count == 10L && p.sealed }
+            listener.messages shouldExist { p -> p.size == "medium" && p.count == 20L && p.sealed }
+            listener.messages shouldExist { p -> p.size == null && p.count == 30L && !p.sealed }
         }
     }
-})
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ rabbit = '5.15.0'
 managed-amqp-client = '5.28.0'
 
 micronaut-micrometer = "5.13.2"
-micronaut-test-resources = "2.10.1"
 micronaut-serde = "3.0.0-M1"
 
 [libraries]
@@ -26,6 +25,5 @@ jsr305 = {group = "com.google.code.findbugs", name = "jsr305", version.ref = "js
 kotest = { module = 'io.kotest:kotest-runner-junit5', version.ref = 'kotest' }
 micronaut-micrometer = { module = "io.micronaut.micrometer:micronaut-micrometer-bom", version.ref = "micronaut-micrometer" }
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
-micronaut-test-resources = { module = "io.micronaut.testresources:micronaut-test-resources-bom", version.ref = "micronaut-test-resources" }
 gradle-micronaut = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = "micronaut-gradle-plugin" }
-
+testcontainers-rabbitmq = { module = "org.testcontainers:testcontainers-rabbitmq" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-micronaut-platform = "4.3.4"
 micronaut = "5.0.0-M3"
+micronaut-platform = "4.10.4"
 micronaut-gradle-plugin = "4.6.1"
 
 awaitility = '4.3.0'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 micronaut = "5.0.0-M3"
 micronaut-platform = "4.10.4"
+micronaut-test = "5.0.0-M2"
 micronaut-gradle-plugin = "4.6.1"
 
 awaitility = '4.3.0'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-micronaut = "5.0.0-M2"
 micronaut-platform = "4.3.4"
+micronaut = "5.0.0-M3"
 micronaut-gradle-plugin = "4.6.1"
 
 awaitility = '4.3.0'

--- a/rabbitmq/build.gradle.kts
+++ b/rabbitmq/build.gradle.kts
@@ -21,8 +21,6 @@ dependencies {
     compileOnly(mnMicrometer.micronaut.micrometer.core)
 
     testImplementation(mnSerde.micronaut.serde.jackson)
-    testImplementation(mnTestResources.testcontainers.core)
-    testImplementation(mnTestResources.testcontainers.rabbitmq)
     testImplementation(mn.micronaut.inject.groovy)
     testImplementation(mn.micronaut.inject.java)
     testImplementation(mn.micronaut.management)
@@ -30,6 +28,8 @@ dependencies {
     testImplementation(mnMicrometer.micronaut.micrometer.core) {
       exclude("io.micronaut.reactor", "micronaut-reactor")
     }
+    testImplementation(platform(mnTest.boms.testcontainers))
+    testImplementation(libs.testcontainers.rabbitmq)
     testRuntimeOnly(mnLogging.logback.classic)
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,5 +25,4 @@ micronautBuild {
     importMicronautCatalog()
     importMicronautCatalog("micronaut-micrometer")
     importMicronautCatalog("micronaut-serde")
-    importMicronautCatalog("micronaut-test-resources")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@ rootProject.name = 'rabbitmq-parent'
 include 'rabbitmq-bom'
 include 'rabbitmq'
 
+include 'test-suite-utils'
 include 'docs-examples:example-groovy'
 include 'docs-examples:example-java'
 include 'docs-examples:example-kotlin'

--- a/test-suite-utils/build.gradle.kts
+++ b/test-suite-utils/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    id("io.micronaut.build.internal.java-base")
+}
+dependencies {
+    implementation(platform(mnTest.boms.testcontainers))
+    implementation(libs.testcontainers.rabbitmq)
+}

--- a/test-suite-utils/src/main/java/io/micronaut/rabbitmq/testcontainers/RabbitMQ.java
+++ b/test-suite-utils/src/main/java/io/micronaut/rabbitmq/testcontainers/RabbitMQ.java
@@ -1,0 +1,37 @@
+package io.micronaut.rabbitmq.testcontainers;
+
+import org.testcontainers.rabbitmq.RabbitMQContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.net.URI;
+import java.util.Map;
+
+public class RabbitMQ {
+    private static final String IMAGE_NAME = "rabbitmq";
+    private static RabbitMQContainer container;
+
+    public static Map<String, String> getProperties() {
+        if (container == null) {
+            container = new RabbitMQContainer(DockerImageName.parse(IMAGE_NAME));
+            container.start();
+            do {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            } while(!container.isRunning());
+            return getProperties(container);
+        } else {
+            return getProperties(container);
+        }
+    }
+
+    private static Map<String, String> getProperties(RabbitMQContainer container) {
+        return Map.of(
+            "rabbitmq.uri", container.getAmqpUrl(),
+            "rabbitmq.username", container.getAdminUsername(),
+            "rabbitmq.password", container.getAdminPassword()//,
+        );
+    }
+}


### PR DESCRIPTION
I had to change the KoTest tests to be `AnnotationSpec` instead of `BehaviorSpec`