### PR TITLE
Fail channel initialization on locked resources

### DIFF
--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/annotation/Mandatory.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/annotation/Mandatory.java
@@ -18,7 +18,12 @@ package io.micronaut.rabbitmq.annotation;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.util.StringUtils;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Used to specify how the server should react if the message cannot be routed to a queue.

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelInitializer.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelInitializer.java
@@ -60,7 +60,14 @@ public abstract class ChannelInitializer implements BeanCreatedEventListener<Cha
             // Check if the connection is just temporarily down
             if (e instanceof TemporarilyDownException temp) {
                 // We will try to initialize the channel again when it's eventually up
-                temp.getConnection().addEventuallyUpListener(c -> initialize(c.createChannel(), pool.getName()));
+                temp.getConnection().addEventuallyUpListener(c -> {
+                    Channel ch = pool.getChannel();
+                    try {
+                        initialize(ch, pool.getName());
+                    } finally {
+                        pool.returnChannel(ch);
+                    }
+                });
                 return pool;
             }
             if (e instanceof Error error) {

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelInitializer.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelInitializer.java
@@ -18,6 +18,7 @@ package io.micronaut.rabbitmq.connect;
 import com.rabbitmq.client.Channel;
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.context.exceptions.BeanInstantiationException;
 import io.micronaut.rabbitmq.connect.recovery.TemporarilyDownException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +61,10 @@ public abstract class ChannelInitializer implements BeanCreatedEventListener<Cha
             if (e instanceof TemporarilyDownException temp) {
                 // We will try to initialize the channel again when it's eventually up
                 temp.getConnection().addEventuallyUpListener(c -> initialize(c.createChannel(), pool.getName()));
+            } else if (e instanceof Error error) {
+                throw error;
+            } else {
+                throw new BeanInstantiationException("Initialization of the channel has failed", e);
             }
         } finally {
             if (channel != null) {

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelInitializer.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelInitializer.java
@@ -61,11 +61,12 @@ public abstract class ChannelInitializer implements BeanCreatedEventListener<Cha
             if (e instanceof TemporarilyDownException temp) {
                 // We will try to initialize the channel again when it's eventually up
                 temp.getConnection().addEventuallyUpListener(c -> initialize(c.createChannel(), pool.getName()));
-            } else if (e instanceof Error error) {
-                throw error;
-            } else {
-                throw new BeanInstantiationException("Initialization of the channel has failed", e);
+                return pool;
             }
+            if (e instanceof Error error) {
+                throw error;
+            }
+            throw new BeanInstantiationException("Initialization of the channel has failed", e);
         } finally {
             if (channel != null) {
                 pool.returnChannel(channel);

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/recovery/TemporarilyDownAutorecoveringConnection.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/recovery/TemporarilyDownAutorecoveringConnection.java
@@ -79,6 +79,7 @@ class TemporarilyDownAutorecoveringConnection extends AutorecoveringConnection i
         );
     }
 
+    @SuppressWarnings({"deprecation", "java:S1874"})
     private static FrameHandlerFactory getFrameHandlerFactory(RabbitConnectionFactoryConfig factory, ExecutorService executor) {
         final int connectionTimeout = factory.getConnectionTimeout();
         final NioParams nioParams = factory.getNioParams();

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/recovery/TemporarilyDownAutorecoveringConnection.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/recovery/TemporarilyDownAutorecoveringConnection.java
@@ -15,7 +15,20 @@
  */
 package io.micronaut.rabbitmq.connect.recovery;
 
-import com.rabbitmq.client.*;
+import com.rabbitmq.client.Address;
+import com.rabbitmq.client.AddressResolver;
+import com.rabbitmq.client.BlockedCallback;
+import com.rabbitmq.client.BlockedListener;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.DnsRecordIpAddressResolver;
+import com.rabbitmq.client.ExceptionHandler;
+import com.rabbitmq.client.ListAddressResolver;
+import com.rabbitmq.client.MetricsCollector;
+import com.rabbitmq.client.NoOpMetricsCollector;
+import com.rabbitmq.client.ShutdownListener;
+import com.rabbitmq.client.ShutdownSignalException;
+import com.rabbitmq.client.SslContextFactory;
+import com.rabbitmq.client.UnblockedCallback;
 import com.rabbitmq.client.impl.ConnectionParams;
 import com.rabbitmq.client.impl.FrameHandlerFactory;
 import com.rabbitmq.client.impl.SocketFrameHandlerFactory;

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/ChannelInitializerSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/ChannelInitializerSpec.groovy
@@ -1,0 +1,81 @@
+package io.micronaut.rabbitmq.connect
+
+import com.rabbitmq.client.Channel
+import io.micronaut.context.event.BeanCreatedEvent
+import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.rabbitmq.connect.recovery.TemporarilyDownConnection
+import io.micronaut.rabbitmq.connect.recovery.TemporarilyDownException
+import spock.lang.Specification
+
+class ChannelInitializerSpec extends Specification {
+
+    void "resource locked initializer failure is not swallowed"() {
+        given:
+        Channel channel = Mock()
+        ChannelPool pool = Mock() {
+            getName() >> "default"
+            getChannel() >> channel
+        }
+        BeanCreatedEvent<ChannelPool> event = Stub() {
+            getBean() >> pool
+        }
+        ChannelInitializer initializer = new ChannelInitializer() {
+            @Override
+            void initialize(Channel ch, String name) throws IOException {
+                throw new IOException("RESOURCE_LOCKED - cannot obtain exclusive access to locked queue")
+            }
+        }
+
+        when:
+        initializer.onCreated(event)
+
+        then:
+        BeanInstantiationException e = thrown()
+        e.message == "Initialization of the channel has failed"
+        e.cause instanceof IOException
+        e.cause.message == "RESOURCE_LOCKED - cannot obtain exclusive access to locked queue"
+        1 * pool.returnChannel(channel)
+    }
+
+    void "temporarily down initializer failure registers eventual up retry"() {
+        given:
+        Channel channel = Mock()
+        TemporarilyDownConnection connection = Mock()
+        ChannelPool pool = Mock() {
+            getName() >> "default"
+            getChannel() >> channel
+        }
+        BeanCreatedEvent<ChannelPool> event = Stub() {
+            getBean() >> pool
+        }
+        ChannelInitializer initializer = new ChannelInitializer() {
+            @Override
+            void initialize(Channel ch, String name) throws IOException {
+                throw new TemporarilyDownInitializationException(connection)
+            }
+        }
+
+        when:
+        ChannelPool created = initializer.onCreated(event)
+
+        then:
+        created.is(pool)
+        1 * connection.addEventuallyUpListener(_)
+        1 * pool.returnChannel(channel)
+    }
+
+    private static class TemporarilyDownInitializationException extends IOException implements TemporarilyDownException {
+
+        private final TemporarilyDownConnection connection
+
+        TemporarilyDownInitializationException(TemporarilyDownConnection connection) {
+            super(ERROR_MESSAGE)
+            this.connection = connection
+        }
+
+        @Override
+        TemporarilyDownConnection getConnection() {
+            connection
+        }
+    }
+}

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/ChannelInitializerSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/ChannelInitializerSpec.groovy
@@ -64,6 +64,33 @@ class ChannelInitializerSpec extends Specification {
         1 * pool.returnChannel(channel)
     }
 
+    void "initializer errors are rethrown"() {
+        given:
+        Channel channel = Mock()
+        ChannelPool pool = Mock() {
+            getName() >> "default"
+            getChannel() >> channel
+        }
+        BeanCreatedEvent<ChannelPool> event = Stub() {
+            getBean() >> pool
+        }
+        Error failure = new AssertionError("fatal")
+        ChannelInitializer initializer = new ChannelInitializer() {
+            @Override
+            void initialize(Channel ch, String name) throws IOException {
+                throw failure
+            }
+        }
+
+        when:
+        initializer.onCreated(event)
+
+        then:
+        Error e = thrown()
+        e.is(failure)
+        1 * pool.returnChannel(channel)
+    }
+
     private static class TemporarilyDownInitializationException extends IOException implements TemporarilyDownException {
 
         private final TemporarilyDownConnection connection


### PR DESCRIPTION
## Summary

- Fail RabbitMQ channel initialization when a non-temporary initializer error occurs, instead of logging and continuing with an unusable listener setup.
- Preserve the existing temporarily-down retry path for connection startup failures.
- Add focused coverage for resource-locked-style initializer failures and temporary-down retry registration.

## Tests

- `./gradlew :micronaut-rabbitmq:test --tests 'io.micronaut.rabbitmq.connect.ChannelInitializerSpec'`
- `./gradlew :micronaut-rabbitmq:spotlessCheck`
- `git diff --check`

Note: `./gradlew :micronaut-rabbitmq:test --tests 'io.micronaut.rabbitmq.connect.TemporarilyDownConsumersSpec'` was also attempted, but RabbitMQ remained unreachable in the local Testcontainers path with `Connection refused`.

Resolves https://github.com/micronaut-projects/micronaut-rabbitmq/issues/742
