### PR TITLE
Fix publisher completion blocking consumers

### DIFF
--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/annotation/Mandatory.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/annotation/Mandatory.java
@@ -18,7 +18,12 @@ package io.micronaut.rabbitmq.annotation;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.util.StringUtils;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Used to specify how the server should react if the message cannot be routed to a queue.

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/recovery/TemporarilyDownAutorecoveringConnection.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/recovery/TemporarilyDownAutorecoveringConnection.java
@@ -15,7 +15,20 @@
  */
 package io.micronaut.rabbitmq.connect.recovery;
 
-import com.rabbitmq.client.*;
+import com.rabbitmq.client.Address;
+import com.rabbitmq.client.AddressResolver;
+import com.rabbitmq.client.BlockedCallback;
+import com.rabbitmq.client.BlockedListener;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.DnsRecordIpAddressResolver;
+import com.rabbitmq.client.ExceptionHandler;
+import com.rabbitmq.client.ListAddressResolver;
+import com.rabbitmq.client.MetricsCollector;
+import com.rabbitmq.client.NoOpMetricsCollector;
+import com.rabbitmq.client.ShutdownListener;
+import com.rabbitmq.client.ShutdownSignalException;
+import com.rabbitmq.client.SslContextFactory;
+import com.rabbitmq.client.UnblockedCallback;
 import com.rabbitmq.client.impl.ConnectionParams;
 import com.rabbitmq.client.impl.FrameHandlerFactory;
 import com.rabbitmq.client.impl.SocketFrameHandlerFactory;

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQIntroductionAdvice.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/intercept/RabbitMQIntroductionAdvice.java
@@ -228,7 +228,8 @@ public class RabbitMQIntroductionAdvice implements MethodInterceptor<Object, Obj
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("Publish is an RPC call. Publisher will complete when a response is received.", context);
                         }
-                        reactive = reactive.subscribeOn(scheduler);
+                        reactive = reactive.subscribeOn(scheduler)
+                                .publishOn(scheduler);
                     }
                 } else {
                     if (interceptedMethod.resultType() == InterceptedMethod.ResultType.SYNCHRONOUS) {
@@ -241,7 +242,8 @@ public class RabbitMQIntroductionAdvice implements MethodInterceptor<Object, Obj
                             LOG.debug("Sending the message with publisher confirms.", context);
                         }
                         reactive = Mono.from(reactivePublisher.publishAndConfirm(publishState))
-                                .subscribeOn(scheduler);
+                                .subscribeOn(scheduler)
+                                .publishOn(scheduler);
                     }
                 }
 

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/reactive/ReactorReactivePublisher.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/reactive/ReactorReactivePublisher.java
@@ -130,7 +130,7 @@ public class ReactorReactivePublisher implements ReactivePublisher {
      * @see Channel#basicPublish(String, String, AMQP.BasicProperties, byte[])
      */
     protected Mono<Object> publishInternal(Channel channel, RabbitPublishState publishState) {
-        return Mono.create(subscriber -> {
+        return returnChannelOnTerminate(channel, Mono.create(subscriber -> {
             Disposable listener = createListener(channel, subscriber, publishState);
             try {
                 channel.basicPublish(
@@ -144,7 +144,7 @@ public class ReactorReactivePublisher implements ReactivePublisher {
                 listener.dispose();
                 subscriber.error(e);
             }
-        }).doFinally(signalType -> returnChannel(channel));
+        }));
     }
 
     /**
@@ -159,7 +159,7 @@ public class ReactorReactivePublisher implements ReactivePublisher {
      * @see Channel#basicPublish(String, String, AMQP.BasicProperties, byte[])
      */
     protected Mono<RabbitConsumerState> publishRpcInternal(Channel channel, RabbitPublishState publishState) {
-        return Mono.<RabbitConsumerState>create(subscriber -> {
+        return returnChannelOnTerminate(channel, Mono.<RabbitConsumerState>create(subscriber -> {
             Disposable listener = null;
             try {
                 String correlationId = UUID.randomUUID().toString();
@@ -179,7 +179,7 @@ public class ReactorReactivePublisher implements ReactivePublisher {
                 }
                 subscriber.error(new MessagingClientException("Failed to publish the message", e));
             }
-        }).doFinally(signalType -> returnChannel(channel));
+        }));
     }
 
     /**
@@ -194,7 +194,7 @@ public class ReactorReactivePublisher implements ReactivePublisher {
      * @see Channel#basicPublish(String, String, AMQP.BasicProperties, byte[])
      */
     protected Mono<Object> publishInternalNoConfirm(Channel channel, RabbitPublishState publishState) {
-        return Mono.create(subscriber -> {
+        return returnChannelOnTerminate(channel, Mono.create(subscriber -> {
             try {
                 channel.basicPublish(
                         publishState.getExchange(),
@@ -208,7 +208,22 @@ public class ReactorReactivePublisher implements ReactivePublisher {
             } catch (IOException e) {
                 subscriber.error(new MessagingClientException("Failed to publish the message", e));
             }
-        }).doFinally(signalType -> returnChannel(channel));
+        }));
+    }
+
+    private <T> Mono<T> returnChannelOnTerminate(Channel channel, Mono<T> publisher) {
+        AtomicBoolean returned = new AtomicBoolean();
+        return publisher
+                .doOnTerminate(returnChannelOnce(channel, returned))
+                .doOnCancel(returnChannelOnce(channel, returned));
+    }
+
+    private Runnable returnChannelOnce(Channel channel, AtomicBoolean returned) {
+        return () -> {
+            if (returned.compareAndSet(false, true)) {
+                returnChannel(channel);
+            }
+        };
     }
 
     /**
@@ -269,12 +284,12 @@ public class ReactorReactivePublisher implements ReactivePublisher {
             }
 
             private void ackNack(long deliveryTag, boolean multiple, boolean ack) {
+                dispose.accept(this);
                 if (ack) {
                     emitter.success();
                 } else {
                     emitter.error(new RabbitClientException("Message could not be delivered to the broker", Collections.singletonList(publishState)));
                 }
-                dispose.accept(this);
             }
         };
 

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/annotation/BasicAopSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/annotation/BasicAopSpec.groovy
@@ -7,6 +7,11 @@ import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
 class BasicAopSpec extends AbstractRabbitMQTest {
 
     void "test simple producing and consuming"() {
@@ -14,6 +19,7 @@ class BasicAopSpec extends AbstractRabbitMQTest {
 
         MyProducer producer = applicationContext.getBean(MyProducer)
         MyConsumer consumer = applicationContext.getBean(MyConsumer)
+        consumer.messages.clear()
 
         when:
         producer.go("abc".bytes)
@@ -52,6 +58,63 @@ class BasicAopSpec extends AbstractRabbitMQTest {
         }
     }
 
+    void "test blocking publisher completion does not block consumers"() {
+        startContext()
+
+        MyProducer producer = applicationContext.getBean(MyProducer)
+        MyConsumer consumer = applicationContext.getBean(MyConsumer)
+        consumer.messages.clear()
+        CountDownLatch completionStarted = new CountDownLatch(1)
+        CountDownLatch releaseCompletion = new CountDownLatch(1)
+        AtomicReference<Throwable> publisherError = new AtomicReference<>()
+
+        when:
+        producer.goConfirm("def".bytes)
+                .subscribe(new Subscriber<Void>() {
+
+                    @Override
+                    void onSubscribe(Subscription s) {
+                        s.request(1)
+                    }
+
+                    @Override
+                    void onNext(Void unused) {
+                    }
+
+                    @Override
+                    void onError(Throwable t) {
+                        publisherError.set(t)
+                        completionStarted.countDown()
+                    }
+
+                    @Override
+                    void onComplete() {
+                        completionStarted.countDown()
+                        try {
+                            releaseCompletion.await(30, TimeUnit.SECONDS)
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt()
+                            publisherError.set(e)
+                        }
+                    }
+                })
+
+        then:
+        completionStarted.await(5, TimeUnit.SECONDS)
+
+        when:
+        producer.go("ghi".bytes)
+
+        then:
+        waitFor {
+            assert consumer.messages.any { it == "ghi".bytes }
+        }
+        publisherError.get() == null
+
+        cleanup:
+        releaseCompletion.countDown()
+    }
+
     @Requires(property = "spec.name", value = "BasicAopSpec")
     @RabbitClient
     static interface MyProducer {
@@ -67,7 +130,7 @@ class BasicAopSpec extends AbstractRabbitMQTest {
     @RabbitListener
     static class MyConsumer {
 
-        static List<byte[]> messages = []
+        static List<byte[]> messages = new CopyOnWriteArrayList<>()
 
         @Queue("abc")
         void listen(byte[] data) {


### PR DESCRIPTION
## Summary
- move non-synchronous RabbitMQ publisher completion signals onto the configured IO scheduler
- return publisher channels before downstream terminal callbacks can block the RabbitMQ callback path
- add a regression for a blocking publisher completion callback while a later message is still consumed

## Verification
- `./gradlew :micronaut-rabbitmq:compileJava :micronaut-rabbitmq:compileTestGroovy`
- `./gradlew :micronaut-rabbitmq:test --tests 'io.micronaut.rabbitmq.annotation.BasicAopSpec'` compiled, but RabbitMQ startup failed locally with `Connection refused` / `Connection is not ready yet` before the assertions ran

Resolves https://github.com/micronaut-projects/micronaut-rabbitmq/issues/801
