### PR TITLE
Add an interface for channel pool initialization

### DIFF
--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelInitializer.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelInitializer.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  * @author James Kleeh
  * @since 1.1.0
  */
-public abstract class ChannelInitializer implements BeanCreatedEventListener<ChannelPool> {
+public abstract class ChannelInitializer implements BeanCreatedEventListener<ChannelPool>, ChannelPoolInitializer {
     private static final Logger LOG = LoggerFactory.getLogger(ChannelInitializer.class);
 
     /**
@@ -42,17 +42,22 @@ public abstract class ChannelInitializer implements BeanCreatedEventListener<Cha
      * @param name The name of the channel pool, like configured under `rabbitmq.servers`
      * @throws IOException If any error occurs
      */
+    @Override
     public void initialize(Channel channel, String name) throws IOException {
         //no-op
     }
 
     @Override
     public ChannelPool onCreated(BeanCreatedEvent<ChannelPool> event) {
+        return initialize(event, this);
+    }
+
+    static ChannelPool initialize(BeanCreatedEvent<ChannelPool> event, ChannelPoolInitializer initializer) {
         ChannelPool pool = event.getBean();
         Channel channel = null;
         try {
             channel = pool.getChannel();
-            initialize(channel, pool.getName());
+            initializer.initialize(channel, pool.getName());
         } catch (Throwable e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Initialization of the channel has failed due to error", e);
@@ -63,7 +68,7 @@ public abstract class ChannelInitializer implements BeanCreatedEventListener<Cha
                 temp.getConnection().addEventuallyUpListener(c -> {
                     Channel ch = pool.getChannel();
                     try {
-                        initialize(ch, pool.getName());
+                        initializer.initialize(ch, pool.getName());
                     } finally {
                         pool.returnChannel(ch);
                     }

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelPoolInitializer.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelPoolInitializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.rabbitmq.connect;
+
+import com.rabbitmq.client.Channel;
+
+import java.io.IOException;
+
+/**
+ * Initializes a channel before consumers or producers are created.
+ *
+ * @author James Kleeh
+ * @since 5.10.0
+ */
+@FunctionalInterface
+public interface ChannelPoolInitializer {
+
+    /**
+     * Do any work with a channel.
+     *
+     * @param channel The channel to use
+     * @param name The name of the channel pool, like configured under {@code rabbitmq.servers}
+     * @throws IOException If any error occurs
+     */
+    void initialize(Channel channel, String name) throws IOException;
+}

--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelPoolInitializers.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/connect/ChannelPoolInitializers.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.rabbitmq.connect;
+
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+/**
+ * Applies {@link ChannelPoolInitializer} beans that do not use the legacy
+ * {@link ChannelInitializer} base class.
+ *
+ * @author James Kleeh
+ * @since 5.10.0
+ */
+@Singleton
+final class ChannelPoolInitializers implements BeanCreatedEventListener<ChannelPool> {
+
+    private final List<ChannelPoolInitializer> initializers;
+
+    ChannelPoolInitializers(List<ChannelPoolInitializer> initializers) {
+        this.initializers = initializers;
+    }
+
+    @Override
+    public ChannelPool onCreated(BeanCreatedEvent<ChannelPool> event) {
+        for (ChannelPoolInitializer initializer : initializers) {
+            if (!(initializer instanceof ChannelInitializer)) {
+                ChannelInitializer.initialize(event, initializer);
+            }
+        }
+        return event.getBean();
+    }
+}

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/ChannelInitializerSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/connect/ChannelInitializerSpec.groovy
@@ -9,6 +9,33 @@ import spock.lang.Specification
 
 class ChannelInitializerSpec extends Specification {
 
+    void "channel pool initializer is an interface"() {
+        expect:
+        ChannelPoolInitializer.interface
+    }
+
+    void "channel pool initializer bean initializes a channel"() {
+        given:
+        Channel channel = Mock()
+        ChannelPool pool = Mock() {
+            getName() >> "default"
+            getChannel() >> channel
+        }
+        BeanCreatedEvent<ChannelPool> event = Stub() {
+            getBean() >> pool
+        }
+        ChannelPoolInitializer initializer = Mock()
+        ChannelPoolInitializers listener = new ChannelPoolInitializers([initializer])
+
+        when:
+        ChannelPool created = listener.onCreated(event)
+
+        then:
+        created.is(pool)
+        1 * initializer.initialize(channel, "default")
+        1 * pool.returnChannel(channel)
+    }
+
     void "resource locked initializer failure is not swallowed"() {
         given:
         Channel channel = Mock()


### PR DESCRIPTION
Adds the ChannelPoolInitializer interface for applications that cannot extend the legacy ChannelInitializer class, while retaining the legacy class for existing applications. A listener adapter applies interface beans without double-invoking legacy initializers.

Focused regression passed: ChannelInitializerSpec (5 tests).