### PR TITLE
Cancel the RPC reply consumer when the subscriber cancels

### DIFF
--- a/rabbitmq/src/main/java/io/micronaut/rabbitmq/reactive/ReactorReactivePublisher.java
+++ b/rabbitmq/src/main/java/io/micronaut/rabbitmq/reactive/ReactorReactivePublisher.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 /**
@@ -159,12 +160,14 @@ public class ReactorReactivePublisher implements ReactivePublisher {
      * @see Channel#basicPublish(String, String, AMQP.BasicProperties, byte[])
      */
     protected Mono<RabbitConsumerState> publishRpcInternal(Channel channel, RabbitPublishState publishState) {
+        AtomicReference<Disposable> replyConsumer = new AtomicReference<>();
         return returnChannelOnTerminate(channel, Mono.<RabbitConsumerState>create(subscriber -> {
             Disposable listener = null;
             try {
                 String correlationId = UUID.randomUUID().toString();
                 AMQP.BasicProperties properties = publishState.getProperties().builder().correlationId(correlationId).build();
                 listener = createConsumer(channel, publishState, correlationId, subscriber);
+                replyConsumer.set(listener);
 
                 channel.basicPublish(
                         publishState.getExchange(),
@@ -179,7 +182,18 @@ public class ReactorReactivePublisher implements ReactivePublisher {
                 }
                 subscriber.error(new MessagingClientException("Failed to publish the message", e));
             }
-        }));
+        })).doOnCancel(() -> {
+            // RabbitMQ permits only one direct reply-to consumer per channel, so the
+            // consumer must be cancelled before returnChannelOnTerminate hands the
+            // channel back to the pool. This hook is registered outside that wrapper
+            // so that it runs first. Disposal is idempotent, leaving the paths that
+            // already dispose (delivery, broker cancel/shutdown, publish failure)
+            // unaffected.
+            Disposable listener = replyConsumer.get();
+            if (listener != null) {
+                listener.dispose();
+            }
+        });
     }
 
     /**

--- a/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/reactive/RpcCancellationSpec.groovy
+++ b/rabbitmq/src/test/groovy/io/micronaut/rabbitmq/reactive/RpcCancellationSpec.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.rabbitmq.reactive
+
+import com.rabbitmq.client.AMQP
+import com.rabbitmq.client.Channel
+import io.micronaut.rabbitmq.connect.ChannelPool
+import io.micronaut.rabbitmq.connect.RabbitConnectionFactoryConfig
+import spock.lang.Specification
+
+class RpcCancellationSpec extends Specification {
+
+    void "test the reply consumer is cancelled before the channel returns to the pool"() {
+        given: "an RPC publish on a channel drawn from the pool"
+        String consumerTag = "amq.ctag-reply-to"
+        Channel channel = Mock(Channel)
+        ChannelPool channelPool = Mock(ChannelPool)
+        RabbitConnectionFactoryConfig config = Mock(RabbitConnectionFactoryConfig)
+        ReactorReactivePublisher publisher = new ReactorReactivePublisher(channelPool, config)
+
+        AMQP.BasicProperties properties = new AMQP.BasicProperties.Builder()
+                .replyTo("amq.rabbitmq.reply-to")
+                .build()
+        RabbitPublishState publishState = new RabbitPublishState(
+                "", "no.consumer.bound.here", false, properties, "hi".bytes)
+
+        when: "the subscriber cancels before a reply arrives, as a timeout would"
+        def subscription = publisher.publishRpcInternal(channel, publishState).subscribe()
+        subscription.dispose()
+
+        then: "the reply consumer was attached and the message published"
+        1 * channel.basicConsume("amq.rabbitmq.reply-to", true, _) >> consumerTag
+        1 * channel.basicPublish(_, _, _, _, _)
+
+        then: "the reply consumer is cancelled"
+        1 * channel.basicCancel(consumerTag)
+
+        then: "and only then is the channel handed back, so it cannot be drawn while still consuming"
+        1 * channelPool.returnChannel(channel)
+    }
+}


### PR DESCRIPTION
Fixes #868

## Problem

`ReactorReactivePublisher#publishRpcInternal` disposes the reply consumer in exactly one place — the `catch (IOException)` branch around `basicPublish`:

```java
} catch (IOException e) {
    if (listener != null) {
        listener.dispose();
    }
    subscriber.error(new MessagingClientException("Failed to publish the message", e));
}
```

The consumer's own callbacks cover the other terminal paths: `handleDelivery`, `handleCancel` and `handleShutdownSignal` all dispose. Subscriber cancellation is the gap. The only hook for it is `returnChannelOnTerminate`, which returns the channel and never touches the consumer:

```java
return publisher
        .doOnTerminate(returnChannelOnce(channel, returned))
        .doOnCancel(returnChannelOnce(channel, returned));
```

So an open channel with a live direct reply-to consumer goes back into the pool. RabbitMQ permits one direct reply-to consumer per channel, so the next RPC drawing that channel fails at `basicConsume` with `406 PRECONDITION_FAILED - reply consumer already set` and that request is lost.

This is on the normal path, not just a fault path: any caller bounding an RPC with `Mono.timeout(...)` or `block(Duration)` cancels when the deadline expires.

## Fix

Keep the `Disposable` returned by `createConsumer` and dispose it from a `doOnCancel` registered *outside* `returnChannelOnTerminate`. Reactor runs cancel hooks from the outermost operator inward, so registering it there means the consumer is cancelled before the channel is handed back — not after, which would leave a window where another caller could draw a channel that is still consuming.

`createConsumer`'s dispose function already guards with an `AtomicBoolean` and swallows `basicCancel` `IOException`s, so calling it from the cancel hook is idempotent and the paths that dispose today are unchanged.

## Testing

`RpcCancellationSpec` subscribes to `publishRpcInternal` with a mocked `Channel` and `ChannelPool`, cancels before any reply arrives, and asserts `basicCancel` is invoked — in a separate `then:` block from `returnChannel`, so Spock also enforces that the cancel happens before the channel goes back to the pool.

Verified with a negative control: reverting only `ReactorReactivePublisher` and keeping the spec fails it with

```
Too few invocations for:

1 * channel.basicCancel(consumerTag)   (0 invocations)

Unmatched invocations (ordered by similarity):

None
```

which is the leak this issue describes.

One note on the test: CONTRIBUTING says the suite needs Docker, and every existing spec extends the Testcontainers-backed `AbstractRabbitMQTest`. I did not have a working Docker daemon available, so I wrote this one as a plain `Specification` against mocks instead. That turned out to suit the case anyway — the defect is in the cancellation wiring rather than in broker behaviour, so mocking makes it deterministic rather than racing a real timeout. Happy to rework it as a container-based spec if you would prefer it to match the rest of the suite.
